### PR TITLE
Luxonの日付をAsia/Tokyoで扱う

### DIFF
--- a/src/components/ui/custom/CustomRankingForm.tsx
+++ b/src/components/ui/custom/CustomRankingForm.tsx
@@ -117,10 +117,14 @@ function getDefaultValues({
 			},
 		},
 		firstUpdate: {
-			term: DateTime.fromISO(firstUpdateRaw ?? "").isValid
+			term: DateTime.fromISO(firstUpdateRaw ?? "", { zone: "Asia/Tokyo" })
+				.isValid
 				? "custom"
 				: ((firstUpdateRaw as TermStrings) ?? "none"),
-			begin: firstUpdate?.toISODate() ?? DateTime.now().toISODate() ?? "",
+			begin:
+				firstUpdate?.toISODate() ??
+				DateTime.now().setZone("Asia/Tokyo").toISODate() ??
+				"",
 			end: "",
 		},
 		status: {
@@ -187,7 +191,7 @@ function formatDateRange(raw: string | TermStrings | undefined): string {
 	}
 
 	// ISO日付形式の処理
-	const date = DateTime.fromISO(raw);
+	const date = DateTime.fromISO(raw, { zone: "Asia/Tokyo" });
 	if (!date.isValid) {
 		return "";
 	}
@@ -394,13 +398,16 @@ const EnableCustomRankingForm: React.FC<
 						type="date"
 						{...register("firstUpdate.begin")}
 						min={
-							DateTime.fromObject({
-								year: 2013,
-								month: 5,
-								day: 1,
-							}).toISODate() ?? ""
+							DateTime.fromObject(
+								{
+									year: 2013,
+									month: 5,
+									day: 1,
+								},
+								{ zone: "Asia/Tokyo" },
+							).toISODate() ?? ""
 						}
-						max={DateTime.now().toISODate() ?? ""}
+						max={DateTime.now().setZone("Asia/Tokyo").toISODate() ?? ""}
 						disabled={
 							useWatch({ control, name: "firstUpdate.term" }) !== "custom"
 						}

--- a/src/components/ui/custom/R18RankingForm.tsx
+++ b/src/components/ui/custom/R18RankingForm.tsx
@@ -152,10 +152,14 @@ function getDefaultValues({
 			},
 		},
 		firstUpdate: {
-			term: DateTime.fromISO(firstUpdateRaw ?? "").isValid
+			term: DateTime.fromISO(firstUpdateRaw ?? "", { zone: "Asia/Tokyo" })
+				.isValid
 				? "custom"
 				: ((firstUpdateRaw as TermStrings) ?? "none"),
-			begin: firstUpdate?.toISODate() ?? DateTime.now().toISODate() ?? "",
+			begin:
+				firstUpdate?.toISODate() ??
+				DateTime.now().setZone("Asia/Tokyo").toISODate() ??
+				"",
 			end: "",
 		},
 		status: {
@@ -356,13 +360,16 @@ const EnableCustomRankingForm: React.FC<R18RankingFormParams & InnerParams> = ({
 						type="date"
 						{...register("firstUpdate.begin")}
 						min={
-							DateTime.fromObject({
-								year: 2013,
-								month: 5,
-								day: 1,
-							}).toISODate() ?? ""
+							DateTime.fromObject(
+								{
+									year: 2013,
+									month: 5,
+									day: 1,
+								},
+								{ zone: "Asia/Tokyo" },
+							).toISODate() ?? ""
 						}
-						max={DateTime.now().toISODate() ?? ""}
+						max={DateTime.now().setZone("Asia/Tokyo").toISODate() ?? ""}
 						disabled={
 							useWatch({ control, name: "firstUpdate.term" }) !== "custom"
 						}

--- a/src/components/ui/ranking/Filter.tsx
+++ b/src/components/ui/ranking/Filter.tsx
@@ -122,13 +122,16 @@ const InnerFilterComponent: React.FC<{ onClose: () => void }> = ({
 						type="date"
 						{...register("firstUpdate.begin")}
 						min={
-							DateTime.fromObject({
-								year: 2013,
-								month: 5,
-								day: 1,
-							}).toISODate() ?? ""
+							DateTime.fromObject(
+								{
+									year: 2013,
+									month: 5,
+									day: 1,
+								},
+								{ zone: "Asia/Tokyo" },
+							).toISODate() ?? ""
 						}
-						max={DateTime.now().toISODate() ?? ""}
+						max={DateTime.now().setZone("Asia/Tokyo").toISODate() ?? ""}
 						disabled={
 							useWatch({ control, name: "firstUpdate.term" }) !== "custom"
 						}

--- a/src/modules/atoms/filter.ts
+++ b/src/modules/atoms/filter.ts
@@ -32,22 +32,28 @@ export function parseDateRange(raw: string | undefined): DateTime | undefined {
 	if (raw.endsWith("days")) {
 		const days = Number.parseInt(raw.slice(0, -4));
 		if (days) {
-			return DateTime.now().startOf("day").minus({ days });
+			return DateTime.now().setZone("Asia/Tokyo").startOf("day").minus({ days });
 		}
 	}
 	if (raw.endsWith("months")) {
 		const months = Number.parseInt(raw.slice(0, -6));
 		if (months) {
-			return DateTime.now().startOf("day").minus({ months });
+			return DateTime.now()
+				.setZone("Asia/Tokyo")
+				.startOf("day")
+				.minus({ months });
 		}
 	}
 	if (raw.endsWith("years")) {
 		const years = Number.parseInt(raw.slice(0, -5));
 		if (years) {
-			return DateTime.now().startOf("day").minus({ months: years });
+			return DateTime.now()
+				.setZone("Asia/Tokyo")
+				.startOf("day")
+				.minus({ months: years });
 		}
 	}
-	const date = raw ? DateTime.fromISO(raw) : undefined;
+	const date = raw ? DateTime.fromISO(raw, { zone: "Asia/Tokyo" }) : undefined;
 	return date?.isValid ? date : undefined;
 }
 
@@ -130,10 +136,14 @@ export const filterConfigAtom = atom<FilterConfig, [FilterConfig], void>(
 				},
 			},
 			firstUpdate: {
-				term: DateTime.fromISO(firstUpdateRaw ?? "").isValid
+				term: DateTime.fromISO(firstUpdateRaw ?? "", { zone: "Asia/Tokyo" })
+					.isValid
 					? "custom"
 					: ((firstUpdateRaw as TermStrings) ?? "none"),
-				begin: firstUpdate?.toISODate() ?? DateTime.now().toISODate() ?? "",
+				begin:
+					firstUpdate?.toISODate() ??
+					DateTime.now().setZone("Asia/Tokyo").toISODate() ??
+					"",
 				end: "",
 			},
 			status: {
@@ -156,7 +166,9 @@ export const filterConfigAtom = atom<FilterConfig, [FilterConfig], void>(
 			storyMaxAtom,
 			config.story.max.enable ? config.story.max.value : undefined,
 		);
-		const firstUpdateBegin = DateTime.fromISO(config.firstUpdate.begin);
+		const firstUpdateBegin = DateTime.fromISO(config.firstUpdate.begin, {
+			zone: "Asia/Tokyo",
+		});
 		set(
 			firstUpdateRawAtom,
 			config.firstUpdate.term === "custom" && firstUpdateBegin.isValid

--- a/src/modules/data/item.ts
+++ b/src/modules/data/item.ts
@@ -193,7 +193,7 @@ const formatRankingHistory = (history: RankingHistoryResult[]) => {
 		rankingData[type] = history
 			.filter((x) => x.type === type)
 			.map(({ date, pt, rank }) => ({
-				date: DateTime.fromJSDate(date),
+				date: DateTime.fromJSDate(date, { zone: "Asia/Tokyo" }),
 				pt,
 				rank,
 			}));

--- a/src/modules/data/ranking.ts
+++ b/src/modules/data/ranking.ts
@@ -33,7 +33,7 @@ const rankingServerFn = createServerFn({ method: "GET" })
 	)
 	.handler(async ({ data: { type, date } }) => {
 		return await ranking()
-			.date(DateTime.fromISO(date).toJSDate())
+			.date(DateTime.fromISO(date, { zone: "Asia/Tokyo" }).toJSDate())
 			.type(type)
 			.execute({ fetchOptions });
 	});

--- a/src/modules/data/ranking.ts
+++ b/src/modules/data/ranking.ts
@@ -32,8 +32,11 @@ const rankingServerFn = createServerFn({ method: "GET" })
 		(data: { type: NarouRankingType; date: string }) => data,
 	)
 	.handler(async ({ data: { type, date } }) => {
+		const dateValue = DateTime.fromISO(date, { zone: "Asia/Tokyo" })
+			.setZone("UTC", { keepLocalTime: true })
+			.toJSDate();
 		return await ranking()
-			.date(DateTime.fromISO(date, { zone: "Asia/Tokyo" }).toJSDate())
+			.date(dateValue)
 			.type(type)
 			.execute({ fetchOptions });
 	});

--- a/src/modules/utils/persister.ts
+++ b/src/modules/utils/persister.ts
@@ -6,7 +6,7 @@ import { DateTime } from "luxon";
  */
 function reviver(key: string, value: unknown): unknown {
 	if (typeof value === "string") {
-		const date = DateTime.fromISO(value);
+		const date = DateTime.fromISO(value, { zone: "Asia/Tokyo" });
 		if (date.isValid) {
 			return date;
 		}

--- a/src/routes/ranking/{-$type}/{-$date}.tsx
+++ b/src/routes/ranking/{-$type}/{-$date}.tsx
@@ -33,7 +33,10 @@ const rankingTypeSteps = {
 	[RankingType.Quarterly]: "",
 } as const;
 
-const minDate = DateTime.fromObject({ year: 2013, month: 5, day: 1 });
+const minDate = DateTime.fromObject(
+	{ year: 2013, month: 5, day: 1 },
+	{ zone: "Asia/Tokyo" },
+);
 const maxDate = DateTime.now().setZone("Asia/Tokyo").startOf("day");
 
 function parseDate(dateString: string | undefined): string {
@@ -42,7 +45,7 @@ function parseDate(dateString: string | undefined): string {
 			DateTime.now().setZone("Asia/Tokyo").startOf("day").toISODate() ?? ""
 		);
 	}
-	const date = DateTime.fromISO(dateString);
+	const date = DateTime.fromISO(dateString, { zone: "Asia/Tokyo" });
 	if (!date.isValid) {
 		return (
 			DateTime.now().setZone("Asia/Tokyo").startOf("day").toISODate() ?? ""
@@ -62,7 +65,7 @@ function RankingPage() {
 	const date = useMemo(() => {
 		const dt = !dateParam
 			? DateTime.now().minus({ hour: 12 }).setZone("Asia/Tokyo").startOf("day")
-			: DateTime.fromISO(dateParam);
+			: DateTime.fromISO(dateParam, { zone: "Asia/Tokyo" });
 		return convertDate(dt, type);
 	}, [dateParam, type]);
 
@@ -72,7 +75,7 @@ function RankingPage() {
 
 	const handleDateChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
-			const newDate = DateTime.fromISO(e.target.value);
+			const newDate = DateTime.fromISO(e.target.value, { zone: "Asia/Tokyo" });
 			if (newDate) {
 				navigate({
 					to: "/ranking/{-$type}/{-$date}",


### PR DESCRIPTION
### Motivation
- Luxonで生成・解析した日付をアプリ全体で`Asia/Tokyo`に統一し、ローカルタイムゾーン差による日時ズレを防止するため。 
- フィルターやフォーム、ランキング取得、履歴、キャッシュ復元など日付を扱う複数箇所で挙動を統一する必要があったため。 

### Description
- `DateTime.fromISO`、`DateTime.fromObject`、`DateTime.fromJSDate`に`{ zone: "Asia/Tokyo" }`を適用してパースをTokyo基準に統一した。 
- `DateTime.now()`で生成する日付出力は`setZone("Asia/Tokyo")`を併用してISO出力をTokyo基準に揃えた。 
- 変更対象の主なファイルは `src/routes/ranking/{-$type}/{-$date}.tsx`、`src/modules/atoms/filter.ts`、`src/modules/utils/persister.ts`、`src/modules/data/ranking.ts`、`src/modules/data/item.ts`、およびカスタムフォーム関連コンポーネントで、サーバー送信用日付やローカルストレージ復元処理（`persister`）も更新している。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d0bbe3ac832999294ab897092808)