### PR TITLE
プリレンダリング時の文字化け防止のためUTF-8メタタグを追加

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -58,6 +58,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang="ja">
 			<head>
+				<meta charSet="utf-8" />
 				<HeadContent />
 			</head>
 			<body>


### PR DESCRIPTION
### Motivation
- プリレンダリングされたHTMLで文字化けが発生するため、出力HTMLに文字エンコーディング宣言を明示する必要がある。

### Description
- `src/routes/__root.tsx` の `RootDocument` 内 `<head>` に `<meta charSet="utf-8" />` を追加してHTMLのエンコーディングを明示した。

### Testing
- `pnpm typecheck` は成功した。
- `pnpm lint` は既存のフォーマット/import順の指摘により失敗（今回の変更箇所とは無関係）。
- `pnpm build` はプリレンダリング中にプロキシ経由の `403` により失敗し、環境要因での検証が必要。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a35239788329908bb52189104240)