### PR TITLE
Add MAIN_PAGE_CACHE_OPTIONS and dynamic TTL for current ranking page cache

### DIFF
--- a/src/modules/utils/cacheMiddleware.ts
+++ b/src/modules/utils/cacheMiddleware.ts
@@ -12,6 +12,12 @@ export type CacheOptions = {
 	visibility?: "public" | "private" | "no-store" | string;
 };
 
+export const MAIN_PAGE_CACHE_OPTIONS: CacheOptions = {
+	maxAge: 3600,
+	sMaxAge: 86400,
+	staleWhileRevalidate: 60,
+};
+
 type CacheHeaders = {
 	readonly "Cache-Control": string;
 	readonly "CDN-Cache-Control"?: string;

--- a/src/routes/custom/{-$type}.tsx
+++ b/src/routes/custom/{-$type}.tsx
@@ -20,7 +20,10 @@ type CustomRankingSearch = {
 };
 
 import { prefetchCustomRanking } from "@/modules/data/custom";
-import { createCacheHeaders } from "@/modules/utils/cacheMiddleware";
+import {
+	MAIN_PAGE_CACHE_OPTIONS,
+	createCacheHeaders,
+} from "@/modules/utils/cacheMiddleware";
 import {
 	buildCustomRankingSearch,
 	parseCustomRankingParams,
@@ -52,7 +55,7 @@ export const Route = createFileRoute("/custom/{-$type}")({
 		await prefetchCustomRanking(queryClient, params, 1);
 	},
 	component: CustomRankingPage,
-	headers: () => createCacheHeaders(),
+	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),
 });
 
 function CustomRankingPage() {

--- a/src/routes/detail/$ncode.tsx
+++ b/src/routes/detail/$ncode.tsx
@@ -3,14 +3,17 @@ import { createFileRoute } from "@tanstack/react-router";
 import { DetailRenderer } from "@/components/ui/detail/DetailRenderer";
 
 import { prefetchDetail } from "@/modules/data/prefetch";
-import { createCacheHeaders } from "@/modules/utils/cacheMiddleware";
+import {
+	MAIN_PAGE_CACHE_OPTIONS,
+	createCacheHeaders,
+} from "@/modules/utils/cacheMiddleware";
 
 export const Route = createFileRoute("/detail/$ncode")({
 	loader: async ({ context: { queryClient }, params: { ncode } }) => {
 		await prefetchDetail(queryClient, ncode);
 	},
 	component: DetailPage,
-	headers: () => createCacheHeaders(),
+	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),
 });
 
 function DetailPage() {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,7 @@
-import { createCacheHeaders } from "@/modules/utils/cacheMiddleware";
+import {
+	MAIN_PAGE_CACHE_OPTIONS,
+	createCacheHeaders,
+} from "@/modules/utils/cacheMiddleware";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
@@ -7,5 +10,5 @@ export const Route = createFileRoute("/")({
 			to: "/ranking/{-$type}/{-$date}",
 		});
 	},
-	headers: () => createCacheHeaders(),
+	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),
 });

--- a/src/routes/r18/detail/$ncode.tsx
+++ b/src/routes/r18/detail/$ncode.tsx
@@ -3,14 +3,17 @@ import { createFileRoute } from "@tanstack/react-router";
 import { DetailRenderer } from "@/components/ui/detail/DetailRenderer";
 
 import { prefetchR18Detail } from "@/modules/data/r18item";
-import { createCacheHeaders } from "@/modules/utils/cacheMiddleware";
+import {
+	MAIN_PAGE_CACHE_OPTIONS,
+	createCacheHeaders,
+} from "@/modules/utils/cacheMiddleware";
 
 export const Route = createFileRoute("/r18/detail/$ncode")({
 	loader: async ({ context: { queryClient }, params: { ncode } }) => {
 		await prefetchR18Detail(queryClient, ncode);
 	},
 	component: R18DetailPage,
-	headers: () => createCacheHeaders(),
+	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),
 });
 
 function R18DetailPage() {

--- a/src/routes/r18/index.tsx
+++ b/src/routes/r18/index.tsx
@@ -6,7 +6,10 @@ import {
 import { RankingType } from "../../modules/interfaces/RankingType";
 
 import { prefetchR18Ranking } from "@/modules/data/r18ranking";
-import { createCacheHeaders } from "@/modules/utils/cacheMiddleware";
+import {
+	MAIN_PAGE_CACHE_OPTIONS,
+	createCacheHeaders,
+} from "@/modules/utils/cacheMiddleware";
 import { parseR18RankingParams } from "@/modules/utils/parseSearch";
 
 export const Route = createFileRoute("/r18/")({
@@ -31,7 +34,7 @@ export const Route = createFileRoute("/r18/")({
 		await prefetchR18Ranking(queryClient, params, 1);
 	},
 	component: R18RankingPageWrapper,
-	headers: () => createCacheHeaders(),
+	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),
 });
 
 function R18RankingPageWrapper() {

--- a/src/routes/r18/ranking/{-$type}.tsx
+++ b/src/routes/r18/ranking/{-$type}.tsx
@@ -7,7 +7,10 @@ import {
 import { RankingType } from "@/modules/interfaces/RankingType";
 
 import { prefetchR18Ranking } from "@/modules/data/r18ranking";
-import { createCacheHeaders } from "@/modules/utils/cacheMiddleware";
+import {
+	MAIN_PAGE_CACHE_OPTIONS,
+	createCacheHeaders,
+} from "@/modules/utils/cacheMiddleware";
 import { parseR18RankingParams } from "@/modules/utils/parseSearch";
 
 export const Route = createFileRoute("/r18/ranking/{-$type}")({
@@ -36,7 +39,7 @@ export const Route = createFileRoute("/r18/ranking/{-$type}")({
 		await prefetchR18Ranking(queryClient, params, 1);
 	},
 	component: R18RankingPageWrapper,
-	headers: () => createCacheHeaders(),
+	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),
 });
 
 function R18RankingPageWrapper() {

--- a/src/routes/ranking/{-$type}/{-$date}.tsx
+++ b/src/routes/ranking/{-$type}/{-$date}.tsx
@@ -62,13 +62,18 @@ export const Route = createFileRoute("/ranking/{-$type}/{-$date}")({
 		await prefetchRanking(queryClient, type, date);
 	},
 	component: RankingPage,
-	headers: ({ params: { date } }) => {
-		if (!date) {
+	headers: ({ params: { type: typeParam, date } }) => {
+		const type = (typeParam as RankingType) ?? RankingType.Daily;
+
+		if (!date && type === RankingType.Daily) {
 			const now = DateTime.now().setZone("Asia/Tokyo");
-			const tomorrowNoon = now.startOf("day").plus({ days: 1, hours: 12 });
+			let nextNoon = now.startOf("day").plus({ hours: 12 });
+			if (now >= nextNoon) {
+				nextNoon = nextNoon.plus({ days: 1 });
+			}
 			const ttl = Math.max(
 				60,
-				Math.floor(tomorrowNoon.diff(now, "seconds").seconds),
+				Math.floor(nextNoon.diff(now, "seconds").seconds),
 			);
 
 			return createCacheHeaders({

--- a/src/routes/ranking/{-$type}/{-$date}.tsx
+++ b/src/routes/ranking/{-$type}/{-$date}.tsx
@@ -20,7 +20,10 @@ import { RankingRender } from "@/components/ui/ranking/RankingRender";
 import { prefetchRanking } from "@/modules/data/prefetch";
 import useRanking from "@/modules/data/ranking";
 import { RankingTypeName } from "@/modules/interfaces/RankingType";
-import { createCacheHeaders } from "@/modules/utils/cacheMiddleware";
+import {
+	MAIN_PAGE_CACHE_OPTIONS,
+	createCacheHeaders,
+} from "@/modules/utils/cacheMiddleware";
 import { addDate, convertDate } from "@/modules/utils/date";
 
 const ButtonLink = createLink(Button);
@@ -59,7 +62,24 @@ export const Route = createFileRoute("/ranking/{-$type}/{-$date}")({
 		await prefetchRanking(queryClient, type, date);
 	},
 	component: RankingPage,
-	headers: () => createCacheHeaders(),
+	headers: ({ params: { date } }) => {
+		if (!date) {
+			const now = DateTime.now().setZone("Asia/Tokyo");
+			const tomorrowNoon = now.startOf("day").plus({ days: 1, hours: 12 });
+			const ttl = Math.max(
+				60,
+				Math.floor(tomorrowNoon.diff(now, "seconds").seconds),
+			);
+
+			return createCacheHeaders({
+				...MAIN_PAGE_CACHE_OPTIONS,
+				maxAge: ttl,
+				sMaxAge: ttl,
+			});
+		}
+
+		return createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS);
+	},
 });
 
 function RankingPage() {

--- a/src/routes/ranking/{-$type}/{-$date}.tsx
+++ b/src/routes/ranking/{-$type}/{-$date}.tsx
@@ -62,10 +62,8 @@ export const Route = createFileRoute("/ranking/{-$type}/{-$date}")({
 		await prefetchRanking(queryClient, type, date);
 	},
 	component: RankingPage,
-	headers: ({ params: { type: typeParam, date } }) => {
-		const type = (typeParam as RankingType) ?? RankingType.Daily;
-
-		if (!date && type === RankingType.Daily) {
+	headers: ({ params: { date } }) => {
+		if (!date) {
 			const now = DateTime.now().setZone("Asia/Tokyo");
 			let nextNoon = now.startOf("day").plus({ hours: 12 });
 			if (now >= nextNoon) {


### PR DESCRIPTION
### Motivation
- Standardize cache header configuration for main pages and allow consistent CDN/browser caching across routes.
- Ensure the ranking page for the current date is cached only until the next update by computing a TTL that expires at Tokyo noon the following day.

### Description
- Export `MAIN_PAGE_CACHE_OPTIONS` from `src/modules/utils/cacheMiddleware.ts` with sensible defaults (`maxAge: 3600`, `sMaxAge: 86400`, `staleWhileRevalidate: 60`).
- Update routes to use `createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS)` instead of the implicit defaults for main pages, including `index`, detail pages, custom ranking, r18 pages, and ranking pages.
- Add special header logic in the ranking route (`/ranking/{-$type}/{-$date}`) to compute a TTL until the next Tokyo noon when the `date` param is missing and merge it into `MAIN_PAGE_CACHE_OPTIONS` for `maxAge`/`sMaxAge`.
- Adjust imports across affected files to include `MAIN_PAGE_CACHE_OPTIONS` where needed.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` and it succeeded.
- Ran the test suite with `yarn test` and all tests passed.
- Ran `yarn lint` and the linter passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9aad80c808329b32645b542c6d0c3)