### PR TITLE
🧹 Refactor PropOver direct DOM manipulation in AdAmazon

### DIFF
--- a/src/components/ui/common/AdAmazon.tsx
+++ b/src/components/ui/common/AdAmazon.tsx
@@ -1,6 +1,6 @@
-import { useEffectOnce } from "@/hooks/useEffectOnce";
 import { useMedia } from "@/hooks/useMedia";
 import { useAtomValue } from "jotai";
+import { useEffect, useRef } from "react";
 
 import { adModeAtom } from "../../../modules/atoms/global";
 
@@ -72,27 +72,29 @@ declare global {
 }
 export const PropOver: React.FC = () => {
 	const adMode = useAtomValue(adModeAtom);
-	useEffectOnce(() => {
-		if (!window) return;
-		if (adMode) {
-			window.amzn_assoc_ad_type = "link_enhancement_widget";
-			window.amzn_assoc_tracking_id = "riel011-22";
-			window.amzn_assoc_linkid = "77015d67c4bcdd9353d9c9f7dcec22fb";
-			window.amzn_assoc_placement = "";
-			window.amzn_assoc_marketplace = "amazon";
-			window.amzn_assoc_region = "JP";
-			const head = document.querySelector("head");
+	const ref = useRef<HTMLDivElement>(null);
 
-			if (!head?.querySelector("#amazon-ad")) {
-				const script = document.createElement("script");
-				script.id = "amazon-ad";
-				script.type = "text/javascript";
-				script.src =
-					"//ws-fe.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&Operation=GetScript&ID=OneJS&WS=1&MarketPlace=JP";
-				head?.appendChild(script);
-			}
+	useEffect(() => {
+		if (typeof window === "undefined" || !adMode || !ref.current) return;
+
+		window.amzn_assoc_ad_type = "link_enhancement_widget";
+		window.amzn_assoc_tracking_id = "riel011-22";
+		window.amzn_assoc_linkid = "77015d67c4bcdd9353d9c9f7dcec22fb";
+		window.amzn_assoc_placement = "";
+		window.amzn_assoc_marketplace = "amazon";
+		window.amzn_assoc_region = "JP";
+
+		if (!document.getElementById("amazon-ad")) {
+			const script = document.createElement("script");
+			script.id = "amazon-ad";
+			script.type = "text/javascript";
+			script.src =
+				"//ws-fe.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&Operation=GetScript&ID=OneJS&WS=1&MarketPlace=JP";
+			ref.current.appendChild(script);
 		}
-	});
+	}, [adMode]);
 
-	return <></>;
+	if (!adMode) return null;
+
+	return <div ref={ref} id="amazon-ad-container" style={{ display: "none" }} />;
 };

--- a/src/components/ui/common/AdAmazon.tsx
+++ b/src/components/ui/common/AdAmazon.tsx
@@ -92,6 +92,15 @@ export const PropOver: React.FC = () => {
 				"//ws-fe.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&Operation=GetScript&ID=OneJS&WS=1&MarketPlace=JP";
 			ref.current.appendChild(script);
 		}
+
+		return () => {
+			if (ref.current) {
+				const script = ref.current.querySelector("#amazon-ad");
+				if (script) {
+					ref.current.removeChild(script);
+				}
+			}
+		};
 	}, [adMode]);
 
 	if (!adMode) return null;

--- a/src/components/ui/common/AdAmazon.tsx
+++ b/src/components/ui/common/AdAmazon.tsx
@@ -84,9 +84,8 @@ export const PropOver: React.FC = () => {
 		window.amzn_assoc_marketplace = "amazon";
 		window.amzn_assoc_region = "JP";
 
-		if (!document.getElementById("amazon-ad")) {
+		if (!ref.current.querySelector('script[src*="amazon-adsystem.com"]')) {
 			const script = document.createElement("script");
-			script.id = "amazon-ad";
 			script.type = "text/javascript";
 			script.src =
 				"//ws-fe.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&Operation=GetScript&ID=OneJS&WS=1&MarketPlace=JP";
@@ -95,7 +94,9 @@ export const PropOver: React.FC = () => {
 
 		return () => {
 			if (ref.current) {
-				const script = ref.current.querySelector("#amazon-ad");
+				const script = ref.current.querySelector(
+					'script[src*="amazon-adsystem.com"]',
+				);
 				if (script) {
 					ref.current.removeChild(script);
 				}
@@ -105,5 +106,5 @@ export const PropOver: React.FC = () => {
 
 	if (!adMode) return null;
 
-	return <div ref={ref} id="amazon-ad-container" style={{ display: "none" }} />;
+	return <div ref={ref} style={{ display: "none" }} />;
 };


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the direct manipulation of `document.head` using vanilla JS APIs (`document.querySelector("head")?.appendChild(...)`) which breaks React lifecycle safety guarantees.

💡 **Why:** Directly manipulating global DOM elements that React does not control bypasses React's diffing algorithm and lifecycle constraints. By moving the script target to a `useRef`-managed, component-scoped `<div>`, the script mount and unmount behavior correctly adheres to the component's render lifecycle (e.g. unmounting gracefully if `adMode` turns off). It also patches a bug where changing the `adMode` atom value after the initial mount would be ignored due to the `useEffectOnce` antipattern.

✅ **Verification:** 
- `pnpm run lint:fix` passed successfully.
- `pnpm run typecheck` passed successfully.
- Code Review validated the correctness, SSR safety of the `typeof window` check, and the fix of the `useEffectOnce` dependency regression.

✨ **Result:** A safer, more robust tracking component fully compatible with React concurrent rendering and Server-Side Rendering constraints.

---
*PR created automatically by Jules for task [2172619182342955147](https://jules.google.com/task/2172619182342955147) started by @deflis*