### PR TITLE
fix(utils): correct mergeObject behavior and add tests

### DIFF
--- a/src/modules/utils/__tests__/mergeObjects.test.ts
+++ b/src/modules/utils/__tests__/mergeObjects.test.ts
@@ -32,6 +32,26 @@ describe("mergeObject", () => {
 		// @ts-ignore
 		expect(mergeObject(target, source)).toEqual({ a: 42 });
 	});
+
+	it("プロトタイプ汚染を防ぐため、特定のキーを無視すること", () => {
+		const target: Record<string, unknown> = {};
+		const payload = JSON.parse('{"__proto__": {"polluted": "yes"}}');
+		const result = mergeObject(target, payload);
+
+		// biome-ignore lint/suspicious/noExplicitAny: needed for prototype testing
+		expect((result as any).__proto__.polluted).toBeUndefined();
+		// biome-ignore lint/suspicious/noExplicitAny: needed for prototype testing
+		expect(({} as any).polluted).toBeUndefined();
+
+		const payloadConstructor = JSON.parse(
+			'{"constructor": {"prototype": {"polluted2": "yes"}}}',
+		);
+		const resultConstructor = mergeObject(target, payloadConstructor);
+
+		expect(resultConstructor.constructor).toBe(Object);
+		// biome-ignore lint/suspicious/noExplicitAny: needed for prototype testing
+		expect(({} as any).polluted2).toBeUndefined();
+	});
 });
 
 describe("mergeObjects", () => {

--- a/src/modules/utils/__tests__/mergeObjects.test.ts
+++ b/src/modules/utils/__tests__/mergeObjects.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { mergeObject, mergeObjects } from "../mergeObjects";
+
+describe("mergeObject", () => {
+	it("シンプルなオブジェクトをマージし、sourceがtargetを上書きすること", () => {
+		const target: any = { a: 1, b: 2 };
+		const source: any = { b: 3, c: 4 };
+		expect(mergeObject(target, source)).toEqual({ a: 1, b: 3, c: 4 });
+	});
+
+	it("ネストされたオブジェクトを深くマージすること", () => {
+		const target: any = { a: { x: 1, y: 2 } };
+		const source: any = { a: { y: 3, z: 4 } };
+		expect(mergeObject(target, source)).toEqual({ a: { x: 1, y: 3, z: 4 } });
+	});
+
+	it("配列はマージせず置き換えること", () => {
+		const target: any = { a: [1, 2] };
+		const source: any = { a: [3, 4, 5] };
+		expect(mergeObject(target, source)).toEqual({ a: [3, 4, 5] });
+	});
+
+	it("null値を正しく処理すること", () => {
+		const target: any = { a: { b: 1 }, c: null };
+		const source: any = { a: null, c: { d: 2 } };
+		expect(mergeObject(target, source)).toEqual({ a: null, c: { d: 2 } });
+	});
+
+	it("プリミティブ値はマージせず置き換えること", () => {
+		const target: any = { a: { b: 1 } };
+		const source: any = { a: 42 };
+		// @ts-ignore
+		expect(mergeObject(target, source)).toEqual({ a: 42 });
+	});
+});
+
+describe("mergeObjects", () => {
+	it("複数のオブジェクトをマージすること", () => {
+		const target: any = { a: 1 };
+		const source1: any = { b: 2 };
+		const source2: any = { c: 3 };
+		expect(mergeObjects(target, source1, source2)).toEqual({ a: 1, b: 2, c: 3 });
+	});
+
+	it("後から指定されたsourceのプロパティで正しく上書きすること", () => {
+		const target: any = { a: 1, b: { c: 2 } };
+		const source1: any = { b: { c: 3, d: 4 } };
+		const source2: any = { b: { c: 5 } };
+		expect(mergeObjects(target, source1, source2)).toEqual({ a: 1, b: { c: 5, d: 4 } });
+	});
+});

--- a/src/modules/utils/__tests__/mergeObjects.test.ts
+++ b/src/modules/utils/__tests__/mergeObjects.test.ts
@@ -3,7 +3,6 @@ import { mergeObject, mergeObjects } from "../mergeObjects";
 
 describe("mergeObject", () => {
 	it("シンプルなオブジェクトをマージし、sourceがtargetを上書きすること", () => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const target: Record<string, unknown> = { a: 1, b: 2 };
 		const source: Record<string, unknown> = { b: 3, c: 4 };
 		expect(mergeObject(target, source)).toEqual({ a: 1, b: 3, c: 4 });

--- a/src/modules/utils/__tests__/mergeObjects.test.ts
+++ b/src/modules/utils/__tests__/mergeObjects.test.ts
@@ -45,7 +45,6 @@ describe("mergeObject", () => {
 	it("プリミティブ値はマージせず置き換えること", () => {
 		const target: Record<string, unknown> = { a: { b: 1 } };
 		const source: Record<string, unknown> = { a: 42 };
-		// @ts-ignore
 		expect(mergeObject(target, source)).toEqual({ a: 42 });
 	});
 

--- a/src/modules/utils/__tests__/mergeObjects.test.ts
+++ b/src/modules/utils/__tests__/mergeObjects.test.ts
@@ -3,32 +3,33 @@ import { mergeObject, mergeObjects } from "../mergeObjects";
 
 describe("mergeObject", () => {
 	it("シンプルなオブジェクトをマージし、sourceがtargetを上書きすること", () => {
-		const target: any = { a: 1, b: 2 };
-		const source: any = { b: 3, c: 4 };
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const target: Record<string, unknown> = { a: 1, b: 2 };
+		const source: Record<string, unknown> = { b: 3, c: 4 };
 		expect(mergeObject(target, source)).toEqual({ a: 1, b: 3, c: 4 });
 	});
 
 	it("ネストされたオブジェクトを深くマージすること", () => {
-		const target: any = { a: { x: 1, y: 2 } };
-		const source: any = { a: { y: 3, z: 4 } };
+		const target: Record<string, unknown> = { a: { x: 1, y: 2 } };
+		const source: Record<string, unknown> = { a: { y: 3, z: 4 } };
 		expect(mergeObject(target, source)).toEqual({ a: { x: 1, y: 3, z: 4 } });
 	});
 
 	it("配列はマージせず置き換えること", () => {
-		const target: any = { a: [1, 2] };
-		const source: any = { a: [3, 4, 5] };
+		const target: Record<string, unknown> = { a: [1, 2] };
+		const source: Record<string, unknown> = { a: [3, 4, 5] };
 		expect(mergeObject(target, source)).toEqual({ a: [3, 4, 5] });
 	});
 
 	it("null値を正しく処理すること", () => {
-		const target: any = { a: { b: 1 }, c: null };
-		const source: any = { a: null, c: { d: 2 } };
+		const target: Record<string, unknown> = { a: { b: 1 }, c: null };
+		const source: Record<string, unknown> = { a: null, c: { d: 2 } };
 		expect(mergeObject(target, source)).toEqual({ a: null, c: { d: 2 } });
 	});
 
 	it("プリミティブ値はマージせず置き換えること", () => {
-		const target: any = { a: { b: 1 } };
-		const source: any = { a: 42 };
+		const target: Record<string, unknown> = { a: { b: 1 } };
+		const source: Record<string, unknown> = { a: 42 };
 		// @ts-ignore
 		expect(mergeObject(target, source)).toEqual({ a: 42 });
 	});
@@ -36,16 +37,23 @@ describe("mergeObject", () => {
 
 describe("mergeObjects", () => {
 	it("複数のオブジェクトをマージすること", () => {
-		const target: any = { a: 1 };
-		const source1: any = { b: 2 };
-		const source2: any = { c: 3 };
-		expect(mergeObjects(target, source1, source2)).toEqual({ a: 1, b: 2, c: 3 });
+		const target: Record<string, unknown> = { a: 1 };
+		const source1: Record<string, unknown> = { b: 2 };
+		const source2: Record<string, unknown> = { c: 3 };
+		expect(mergeObjects(target, source1, source2)).toEqual({
+			a: 1,
+			b: 2,
+			c: 3,
+		});
 	});
 
 	it("後から指定されたsourceのプロパティで正しく上書きすること", () => {
-		const target: any = { a: 1, b: { c: 2 } };
-		const source1: any = { b: { c: 3, d: 4 } };
-		const source2: any = { b: { c: 5 } };
-		expect(mergeObjects(target, source1, source2)).toEqual({ a: 1, b: { c: 5, d: 4 } });
+		const target: Record<string, unknown> = { a: 1, b: { c: 2 } };
+		const source1: Record<string, unknown> = { b: { c: 3, d: 4 } };
+		const source2: Record<string, unknown> = { b: { c: 5 } };
+		expect(mergeObjects(target, source1, source2)).toEqual({
+			a: 1,
+			b: { c: 5, d: 4 },
+		});
 	});
 });

--- a/src/modules/utils/__tests__/mergeObjects.test.ts
+++ b/src/modules/utils/__tests__/mergeObjects.test.ts
@@ -8,6 +8,22 @@ describe("mergeObject", () => {
 		expect(mergeObject(target, source)).toEqual({ a: 1, b: 3, c: 4 });
 	});
 
+	it("sourceとtargetにしかないキーが正しくマージされること", () => {
+		const target: Record<string, unknown> = {
+			targetOnly: "targetValue",
+			shared: "t",
+		};
+		const source: Record<string, unknown> = {
+			sourceOnly: "sourceValue",
+			shared: "s",
+		};
+		expect(mergeObject(target, source)).toEqual({
+			targetOnly: "targetValue",
+			sourceOnly: "sourceValue",
+			shared: "s",
+		});
+	});
+
 	it("ネストされたオブジェクトを深くマージすること", () => {
 		const target: Record<string, unknown> = { a: { x: 1, y: 2 } };
 		const source: Record<string, unknown> = { a: { y: 3, z: 4 } };

--- a/src/modules/utils/mergeObjects.ts
+++ b/src/modules/utils/mergeObjects.ts
@@ -7,21 +7,18 @@ export function mergeObjects<T extends object>(target: T, ...sources: T[]): T {
 	return mergeObjects(newObj, ...sources.slice(1));
 }
 
+function isMergeableObject(val: unknown): val is object {
+	return typeof val === "object" && val !== null && !Array.isArray(val);
+}
+
 export function mergeObject<T extends object>(target: T, source: T): T {
 	const newObj: T = { ...target, ...source };
 
 	for (const key of Object.keys(source) as Array<keyof T>) {
 		const tObj = target[key];
 		const sObj = source[key];
-		if (
-			typeof tObj === "object" &&
-			tObj !== null &&
-			!Array.isArray(tObj) &&
-			typeof sObj === "object" &&
-			sObj !== null &&
-			!Array.isArray(sObj)
-		) {
-			newObj[key] = mergeObject(tObj as object, sObj as object) as T[keyof T];
+		if (isMergeableObject(tObj) && isMergeableObject(sObj)) {
+			newObj[key] = mergeObject(tObj, sObj) as T[keyof T];
 		}
 	}
 

--- a/src/modules/utils/mergeObjects.ts
+++ b/src/modules/utils/mergeObjects.ts
@@ -8,7 +8,7 @@ export function mergeObjects<T extends object>(target: T, ...sources: T[]): T {
 }
 
 export function mergeObject<T extends object>(target: T, source: T): T {
-	const newObj: T = { ...source, ...target };
+	const newObj: T = { ...target, ...source };
 
 	for (const key of Object.keys(source) as Array<keyof T>) {
 		const tObj = target[key];
@@ -16,12 +16,14 @@ export function mergeObject<T extends object>(target: T, source: T): T {
 		if (
 			typeof tObj === "object" &&
 			tObj !== null &&
+			!Array.isArray(tObj) &&
 			typeof sObj === "object" &&
-			sObj !== null
+			sObj !== null &&
+			!Array.isArray(sObj)
 		) {
-			newObj[key] = { ...sObj, ...mergeObject(tObj as object, sObj as object) };
+			newObj[key] = mergeObject(tObj as object, sObj as object) as T[keyof T];
 		}
 	}
 
-	return { ...target, ...source, ...newObj };
+	return newObj;
 }

--- a/src/modules/utils/mergeObjects.ts
+++ b/src/modules/utils/mergeObjects.ts
@@ -12,13 +12,19 @@ function isMergeableObject(val: unknown): val is object {
 }
 
 export function mergeObject<T extends object>(target: T, source: T): T {
-	const newObj: T = { ...target, ...source };
+	const newObj: T = { ...target };
 
 	for (const key of Object.keys(source) as Array<keyof T>) {
+		if (key === "__proto__" || key === "constructor" || key === "prototype") {
+			continue;
+		}
+
 		const tObj = target[key];
 		const sObj = source[key];
 		if (isMergeableObject(tObj) && isMergeableObject(sObj)) {
 			newObj[key] = mergeObject(tObj, sObj) as T[keyof T];
+		} else {
+			newObj[key] = sObj;
 		}
 	}
 


### PR DESCRIPTION
- Added comprehensive unit tests for `mergeObject` and `mergeObjects` utility functions (test descriptions in Japanese).
- Fixed bugs in `mergeObject`:
  - Fixed property precedence where `target` was incorrectly overriding `source` values.
  - Added guards to ensure arrays and primitive values are fully replaced by the `source` object instead of improperly merged.
- Verified fixes using `vitest` unit tests.
- Removed local scratchpad debug files.

---
*PR created automatically by Jules for task [9321474088191488093](https://jules.google.com/task/9321474088191488093) started by @deflis*