### PR TITLE
Refactor: Replace Server Functions with direct client-side fetching

### DIFF
--- a/src/modules/data/custom.ts
+++ b/src/modules/data/custom.ts
@@ -4,7 +4,6 @@ import {
 	useQueryClient,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import { createServerFn } from "@tanstack/react-start";
 import type { DateTime } from "luxon";
 import {
 	Fields,
@@ -22,7 +21,6 @@ import type { CustomRankingParams } from "../interfaces/CustomRankingParams";
 import { RankingType } from "../interfaces/RankingType";
 import { parse } from "../utils/NarouDateFormat";
 
-import { cacheMiddleware } from "../utils/cacheMiddleware";
 import {
 	type RankingData,
 	convertOrder,
@@ -193,94 +191,6 @@ type NarouCustomRankingSearchResults = NarouSearchResults<
 	NarouSearchResult,
 	CustomRankingResultKeyNames
 >;
-type CustomRankingServerParams = {
-	order: ReturnType<typeof convertOrder>;
-	keyword: string | undefined;
-	notKeyword: string | undefined;
-	byTitle: boolean;
-	byStory: boolean;
-	firstUpdate?: string | null;
-	genres: readonly Genre[];
-	novelTypeParam: NovelTypeParam | null;
-	fields: readonly Fields[];
-	optionalFields: "weekly"[];
-	page: number;
-};
-const customRankingServerFn = createServerFn({ method: "GET" })
-	.middleware([cacheMiddleware()])
-	.inputValidator((data: CustomRankingServerParams) => data)
-	.handler(
-		async ({
-			data: {
-				order,
-				keyword,
-				notKeyword,
-				byTitle,
-				byStory,
-				firstUpdate,
-				genres,
-				novelTypeParam,
-				fields,
-				optionalFields,
-				page,
-			},
-		}) => {
-			const firstUpdateDate = firstUpdate ? new Date(firstUpdate) : null;
-			const searchBuilder = search()
-				.order(order)
-				.page(page, CHUNK_ITEM_NUM)
-				.fields([
-					Fields.ncode,
-					Fields.general_all_no,
-					Fields.general_firstup,
-					Fields.noveltype,
-					Fields.end,
-					Fields.daily_point,
-					Fields.weekly_point,
-					Fields.monthly_point,
-					Fields.monthly_point,
-					Fields.quarter_point,
-					Fields.yearly_point,
-					Fields.all_hyoka_cnt,
-				])
-				.opt("weekly");
-
-			searchBuilder.fields(fields);
-			searchBuilder.opt(optionalFields);
-
-			if (genres.length > 0) {
-				searchBuilder.genre(genres);
-			}
-			if (keyword) {
-				searchBuilder.word(keyword).byKeyword(true);
-			}
-			if (notKeyword) {
-				searchBuilder.notWord(notKeyword).byKeyword(true);
-			}
-			if (byTitle) {
-				searchBuilder.byTitle(byTitle);
-			}
-			if (byStory) {
-				searchBuilder.byOutline();
-			}
-			if (firstUpdateDate) {
-				// firstUpdateが指定されているということは最終更新日はfirstUpdateよりも新しいので、lastUpdateにfirstUpdateを指定する
-				searchBuilder.lastUpdate(firstUpdateDate, new Date());
-			}
-			if (novelTypeParam) {
-				searchBuilder.type(novelTypeParam);
-			}
-			const result = await searchBuilder.execute({ fetchOptions });
-			return {
-				allcount: result.allcount,
-				limit: result.limit,
-				start: result.start,
-				page: result.page,
-				length: result.length,
-				values: result.values,
-			};
-		},
-	);
 const customRankingFetcher: QueryFunction<
 	NarouCustomRankingSearchResults,
 	CustomRankingKey
@@ -300,21 +210,60 @@ const customRankingFetcher: QueryFunction<
 		page,
 	],
 }) => {
-	return await customRankingServerFn({
-		data: {
-			order,
-			keyword,
-			notKeyword,
-			byTitle,
-			byStory,
-			firstUpdate,
-			genres,
-			novelTypeParam,
-			fields,
-			optionalFields,
-			page,
-		},
-	});
+	const firstUpdateDate = firstUpdate ? new Date(firstUpdate) : null;
+	const searchBuilder = search()
+		.order(order)
+		.page(page, CHUNK_ITEM_NUM)
+		.fields([
+			Fields.ncode,
+			Fields.general_all_no,
+			Fields.general_firstup,
+			Fields.noveltype,
+			Fields.end,
+			Fields.daily_point,
+			Fields.weekly_point,
+			Fields.monthly_point,
+			Fields.monthly_point,
+			Fields.quarter_point,
+			Fields.yearly_point,
+			Fields.all_hyoka_cnt,
+		])
+		.opt("weekly");
+
+	searchBuilder.fields(fields);
+	searchBuilder.opt(optionalFields);
+
+	if (genres.length > 0) {
+		searchBuilder.genre(genres);
+	}
+	if (keyword) {
+		searchBuilder.word(keyword).byKeyword(true);
+	}
+	if (notKeyword) {
+		searchBuilder.notWord(notKeyword).byKeyword(true);
+	}
+	if (byTitle) {
+		searchBuilder.byTitle(byTitle);
+	}
+	if (byStory) {
+		searchBuilder.byOutline();
+	}
+	if (firstUpdateDate) {
+		// firstUpdateが指定されているということは最終更新日はfirstUpdateよりも新しいので、lastUpdateにfirstUpdateを指定する
+		searchBuilder.lastUpdate(firstUpdateDate, new Date());
+	}
+	if (novelTypeParam) {
+		searchBuilder.type(novelTypeParam);
+	}
+	const result = await searchBuilder.execute({ fetchOptions });
+	return {
+		allcount: result.allcount,
+		limit: result.limit,
+		start: result.start,
+		page: result.page,
+		length: result.length,
+		values: result.values,
+	};
 };
 export class FilterBuilder<
 	T extends PickedNarouSearchResult<

--- a/src/modules/data/custom.ts
+++ b/src/modules/data/custom.ts
@@ -223,7 +223,6 @@ const customRankingFetcher: QueryFunction<
 			Fields.daily_point,
 			Fields.weekly_point,
 			Fields.monthly_point,
-			Fields.monthly_point,
 			Fields.quarter_point,
 			Fields.yearly_point,
 			Fields.all_hyoka_cnt,

--- a/src/modules/data/item.ts
+++ b/src/modules/data/item.ts
@@ -3,7 +3,6 @@ import {
 	useSuspenseQueries,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import { createServerFn } from "@tanstack/react-start";
 import DataLoader from "dataloader";
 import { DateTime } from "luxon";
 import {
@@ -16,7 +15,6 @@ import {
 
 import { parseDate } from "../utils/date";
 
-import { cacheMiddleware } from "../utils/cacheMiddleware";
 import { fetchOptions } from "./custom/utils";
 import type { Detail, Item, RankingHistories } from "./types";
 
@@ -41,7 +39,7 @@ export const itemRankingHistoryFetcher: QueryFunction<
 	RankingHistories,
 	ReturnType<typeof itemRankingHistoryKey>
 > = async ({ queryKey: [, ncode] }) => {
-	const history = await itemRankingHistoryServerFn({ data: { ncode } });
+	const history = await rankingHistory(ncode, { fetchOptions });
 	return formatRankingHistory(history);
 };
 
@@ -94,10 +92,8 @@ export const useDetailForView = (ncode: string) => {
 	};
 };
 
-const itemLoaderServerFn = createServerFn({ method: "GET" })
-	.middleware([cacheMiddleware()])
-	.inputValidator((data: { ncodes: readonly string[] }) => data)
-	.handler(async ({ data: { ncodes } }) => {
+const itemLoader = new DataLoader<string, Item | undefined>(
+	async (ncodes) => {
 		if (ncodes.length === 0) {
 			return [];
 		}
@@ -123,12 +119,6 @@ const itemLoaderServerFn = createServerFn({ method: "GET" })
 			])
 			.execute({ fetchOptions });
 
-		return values;
-	});
-
-const itemLoader = new DataLoader<string, Item | undefined>(
-	async (ncodes) => {
-		const values = await itemLoaderServerFn({ data: { ncodes } });
 		const resultMap = new Map(
 			values.map(
 				({ general_firstup, general_lastup, novelupdated_at, ...others }) => {
@@ -150,10 +140,8 @@ const itemLoader = new DataLoader<string, Item | undefined>(
 	},
 );
 
-const itemDetailLoaderServerFn = createServerFn({ method: "GET" })
-	.middleware([cacheMiddleware()])
-	.inputValidator((data: { ncodes: readonly string[] }) => data)
-	.handler(async ({ data: { ncodes } }) => {
+const itemDetailLoader = new DataLoader<string, Detail | undefined>(
+	async (ncodes) => {
 		if (ncodes.length === 0) {
 			return [];
 		}
@@ -178,19 +166,6 @@ const itemDetailLoaderServerFn = createServerFn({ method: "GET" })
 			.opt("weekly")
 			.execute({ fetchOptions });
 
-		return values;
-	});
-
-const itemRankingHistoryServerFn = createServerFn({ method: "GET" })
-	.middleware([cacheMiddleware()])
-	.inputValidator((data: { ncode: string }) => data)
-	.handler(async ({ data: { ncode } }) => {
-		return await rankingHistory(ncode, { fetchOptions });
-	});
-
-const itemDetailLoader = new DataLoader<string, Detail | undefined>(
-	async (ncodes) => {
-		const values = await itemDetailLoaderServerFn({ data: { ncodes } });
 		const resultMap = new Map(
 			values.map((value) => [value.ncode.toLowerCase(), value]),
 		);

--- a/src/modules/data/r18item.ts
+++ b/src/modules/data/r18item.ts
@@ -4,13 +4,11 @@ import {
 	useSuspenseQueries,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import { createServerFn } from "@tanstack/react-start";
 import DataLoader from "dataloader";
 import { R18Fields, searchR18 } from "narou";
 
 import { parseDate } from "../utils/date";
 
-import { cacheMiddleware } from "../utils/cacheMiddleware";
 import { fetchOptions } from "./custom/utils";
 import type { NocDetail, NocItem } from "./types";
 
@@ -83,32 +81,6 @@ export const useR18DetailForView = (ncode: string) => {
 
 const itemLoader = new DataLoader<string, NocItem | undefined>(
 	async (ncodes) => {
-		const values = await itemLoaderServerFn({ data: { ncodes } });
-		const resultMap = new Map(
-			values.map(
-				({ general_firstup, general_lastup, novelupdated_at, ...others }) => {
-					const item: NocItem = {
-						general_firstup: parseDate(general_firstup).toISO(),
-						general_lastup: parseDate(general_lastup).toISO(),
-						novelupdated_at: parseDate(novelupdated_at).toISO(),
-						...others,
-					};
-					return [others.ncode.toLowerCase(), item];
-				},
-			),
-		);
-		return ncodes.map((ncode) => resultMap.get(ncode.toLowerCase()));
-	},
-	{
-		cache: false,
-		maxBatchSize: 500,
-	},
-);
-
-const itemLoaderServerFn = createServerFn({ method: "GET" })
-	.middleware([cacheMiddleware()])
-	.inputValidator((data: { ncodes: readonly string[] }) => data)
-	.handler(async ({ data: { ncodes } }) => {
 		if (ncodes.length === 0) {
 			return [];
 		}
@@ -134,13 +106,29 @@ const itemLoaderServerFn = createServerFn({ method: "GET" })
 			])
 			.execute({ fetchOptions });
 
-		return values;
-	});
+		const resultMap = new Map(
+			values.map(
+				({ general_firstup, general_lastup, novelupdated_at, ...others }) => {
+					const item: NocItem = {
+						general_firstup: parseDate(general_firstup).toISO(),
+						general_lastup: parseDate(general_lastup).toISO(),
+						novelupdated_at: parseDate(novelupdated_at).toISO(),
+						...others,
+					};
+					return [others.ncode.toLowerCase(), item];
+				},
+			),
+		);
+		return ncodes.map((ncode) => resultMap.get(ncode.toLowerCase()));
+	},
+	{
+		cache: false,
+		maxBatchSize: 500,
+	},
+);
 
-const itemDetailLoaderServerFn = createServerFn({ method: "GET" })
-	.middleware([cacheMiddleware()])
-	.inputValidator((data: { ncodes: readonly string[] }) => data)
-	.handler(async ({ data: { ncodes } }) => {
+const itemDetailLoader = new DataLoader<string, NocDetail | undefined>(
+	async (ncodes) => {
 		if (ncodes.length === 0) {
 			return [];
 		}
@@ -165,12 +153,6 @@ const itemDetailLoaderServerFn = createServerFn({ method: "GET" })
 			.opt("weekly")
 			.execute({ fetchOptions });
 
-		return values;
-	});
-
-const itemDetailLoader = new DataLoader<string, NocDetail | undefined>(
-	async (ncodes) => {
-		const values = await itemDetailLoaderServerFn({ data: { ncodes } });
 		const resultMap = new Map(
 			values.map((value) => [value.ncode.toLowerCase(), value]),
 		);

--- a/src/modules/data/r18ranking.ts
+++ b/src/modules/data/r18ranking.ts
@@ -5,7 +5,6 @@ import {
 	useQueryClient,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import { createServerFn } from "@tanstack/react-start";
 import type { DateTime } from "luxon";
 import {
 	type NarouSearchResult,
@@ -23,7 +22,6 @@ import type { R18RankingParams } from "../interfaces/CustomRankingParams";
 import { RankingType } from "../interfaces/RankingType";
 import { parse } from "../utils/NarouDateFormat";
 
-import { cacheMiddleware } from "../utils/cacheMiddleware";
 import {
 	type RankingData,
 	convertOrder,
@@ -198,87 +196,6 @@ type NarouCustomRankingSearchResults = NarouSearchResults<
 	NarouSearchResult,
 	CustomRankingResultKeyNames
 >;
-type CustomRankingServerParams = {
-	order: ReturnType<typeof convertOrder>;
-	keyword: string | undefined;
-	notKeyword: string | undefined;
-	byTitle: boolean;
-	byStory: boolean;
-	sites: readonly R18Site[];
-	novelTypeParam: NovelTypeParam | null;
-	fields: readonly R18Fields[];
-	optionalFields: "weekly"[];
-	page: number;
-};
-const customRankingServerFn = createServerFn({ method: "GET" })
-	.middleware([cacheMiddleware()])
-	.inputValidator((data: CustomRankingServerParams) => data)
-	.handler(
-		async ({
-			data: {
-				order,
-				keyword,
-				notKeyword,
-				byTitle,
-				byStory,
-				sites,
-				novelTypeParam,
-				fields,
-				optionalFields,
-				page,
-			},
-		}) => {
-			const searchBuilder = searchR18()
-				.order(order)
-				.page(page, CHUNK_ITEM_NUM)
-				.fields([
-					R18Fields.ncode,
-					R18Fields.general_all_no,
-					R18Fields.general_firstup,
-					R18Fields.noveltype,
-					R18Fields.end,
-					R18Fields.daily_point,
-					R18Fields.weekly_point,
-					R18Fields.monthly_point,
-					R18Fields.monthly_point,
-					R18Fields.quarter_point,
-					R18Fields.yearly_point,
-					R18Fields.all_hyoka_cnt,
-				])
-				.opt("weekly");
-
-			searchBuilder.fields(fields);
-			searchBuilder.opt(optionalFields);
-
-			if (sites.length > 0) {
-				searchBuilder.r18Site(sites);
-			}
-			if (keyword) {
-				searchBuilder.word(keyword).byKeyword(true);
-			}
-			if (notKeyword) {
-				searchBuilder.notWord(notKeyword).byKeyword(true);
-			}
-			if (byTitle) {
-				searchBuilder.byTitle(byTitle);
-			}
-			if (byStory) {
-				searchBuilder.byOutline();
-			}
-			if (novelTypeParam) {
-				searchBuilder.type(novelTypeParam);
-			}
-			const result = await searchBuilder.execute({ fetchOptions });
-			return {
-				allcount: result.allcount,
-				limit: result.limit,
-				start: result.start,
-				page: result.page,
-				length: result.length,
-				values: result.values,
-			};
-		},
-	);
 const customRankingFetcher: QueryFunction<
 	NarouCustomRankingSearchResults,
 	CustomRankingKey
@@ -297,20 +214,55 @@ const customRankingFetcher: QueryFunction<
 		page,
 	],
 }) => {
-	return await customRankingServerFn({
-		data: {
-			order,
-			keyword,
-			notKeyword,
-			byTitle,
-			byStory,
-			sites,
-			novelTypeParam,
-			fields,
-			optionalFields,
-			page,
-		},
-	});
+	const searchBuilder = searchR18()
+		.order(order)
+		.page(page, CHUNK_ITEM_NUM)
+		.fields([
+			R18Fields.ncode,
+			R18Fields.general_all_no,
+			R18Fields.general_firstup,
+			R18Fields.noveltype,
+			R18Fields.end,
+			R18Fields.daily_point,
+			R18Fields.weekly_point,
+			R18Fields.monthly_point,
+			R18Fields.monthly_point,
+			R18Fields.quarter_point,
+			R18Fields.yearly_point,
+			R18Fields.all_hyoka_cnt,
+		])
+		.opt("weekly");
+
+	searchBuilder.fields(fields);
+	searchBuilder.opt(optionalFields);
+
+	if (sites.length > 0) {
+		searchBuilder.r18Site(sites);
+	}
+	if (keyword) {
+		searchBuilder.word(keyword).byKeyword(true);
+	}
+	if (notKeyword) {
+		searchBuilder.notWord(notKeyword).byKeyword(true);
+	}
+	if (byTitle) {
+		searchBuilder.byTitle(byTitle);
+	}
+	if (byStory) {
+		searchBuilder.byOutline();
+	}
+	if (novelTypeParam) {
+		searchBuilder.type(novelTypeParam);
+	}
+	const result = await searchBuilder.execute({ fetchOptions });
+	return {
+		allcount: result.allcount,
+		limit: result.limit,
+		start: result.start,
+		page: result.page,
+		length: result.length,
+		values: result.values,
+	};
 };
 
 class FilterBuilder<

--- a/src/modules/data/r18ranking.ts
+++ b/src/modules/data/r18ranking.ts
@@ -226,7 +226,6 @@ const customRankingFetcher: QueryFunction<
 			R18Fields.daily_point,
 			R18Fields.weekly_point,
 			R18Fields.monthly_point,
-			R18Fields.monthly_point,
 			R18Fields.quarter_point,
 			R18Fields.yearly_point,
 			R18Fields.all_hyoka_cnt,

--- a/src/modules/data/ranking.ts
+++ b/src/modules/data/ranking.ts
@@ -22,24 +22,33 @@ export const rankingFetcher: QueryFunction<
 	NarouRankingResult[],
 	ReturnType<typeof rankingKey>
 > = async ({ queryKey: [, type, date] }) => {
-	const dateValue = DateTime.fromISO(date, { zone: "Asia/Tokyo" })
+	const requestDate = DateTime.fromISO(date, { zone: "Asia/Tokyo" });
+	const now = DateTime.now().setZone("Asia/Tokyo");
+
+	const isGenerated =
+		now.startOf("day") > requestDate.startOf("day") || now.hour >= 12;
+
+	const dateValue = requestDate
 		.setZone("UTC", { keepLocalTime: true })
 		.toJSDate();
+
 	return await ranking()
 		.date(dateValue)
 		.type(type)
 		.execute({
 			fetchOptions: {
 				...fetchOptions,
-				cf: {
-					cacheTtlByStatus: {
-						"200-299": 60 * 60 * 24 * 30, // 30 日
-						404: 1,
-						"500-599": 0,
-					},
-					cacheEverything: true,
-				},
-			}, // TTLは伸ばしていないが、未生成のランキングのエラーをキャッシュするのは避けたい
+				cf: isGenerated
+					? {
+							cacheTtlByStatus: {
+								"200-299": 60 * 60 * 24 * 30, // 30 日
+								404: 1,
+								"500-599": 0,
+							},
+							cacheEverything: true,
+						}
+					: undefined,
+			},
 		});
 };
 

--- a/src/modules/data/ranking.ts
+++ b/src/modules/data/ranking.ts
@@ -25,8 +25,7 @@ export const rankingFetcher: QueryFunction<
 	const requestDate = DateTime.fromISO(date, { zone: "Asia/Tokyo" });
 	const now = DateTime.now().setZone("Asia/Tokyo");
 
-	const isGenerated =
-		now.startOf("day") > requestDate.startOf("day") || now.hour >= 12;
+	const isGenerated = now >= requestDate.startOf("day").plus({ hours: 12 });
 
 	const dateValue = requestDate
 		.setZone("UTC", { keepLocalTime: true })

--- a/src/modules/data/ranking.ts
+++ b/src/modules/data/ranking.ts
@@ -38,16 +38,14 @@ export const rankingFetcher: QueryFunction<
 		.execute({
 			fetchOptions: {
 				...fetchOptions,
-				cf: isGenerated
-					? {
-							cacheTtlByStatus: {
-								"200-299": 60 * 60 * 24 * 30, // 30 日
-								404: 1,
-								"500-599": 0,
-							},
-							cacheEverything: true,
-						}
-					: undefined,
+				cf: {
+					cacheTtlByStatus: {
+						"200-299": isGenerated ? 60 * 60 * 24 * 30 : 60 * 5, // 生成済みなら30日、未生成(当日等)なら5分
+						404: 1,
+						"500-599": 0,
+					},
+					cacheEverything: true,
+				},
 			},
 		});
 };

--- a/src/modules/data/ranking.ts
+++ b/src/modules/data/ranking.ts
@@ -26,7 +26,17 @@ export const rankingFetcher: QueryFunction<
 		.setZone("UTC", { keepLocalTime: true })
 		.toJSDate();
 	return await ranking().date(dateValue).type(type).execute({
-		fetchOptions,
+		fetchOptions: {
+			...fetchOptions,
+			cf: {
+				cacheTtlByStatus: {
+					"200-299": 60 * 60 * 24 * 30, // 30 日
+					404: 1,
+					"500-599": 0,
+				},
+				cacheEverything: true,
+			},
+		}, // TTLは伸ばしていないが、未生成のランキングのエラーをキャッシュするのは避けたい
 	});
 };
 

--- a/src/modules/data/ranking.ts
+++ b/src/modules/data/ranking.ts
@@ -3,7 +3,6 @@ import {
 	useSuspenseQueries,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import { createServerFn } from "@tanstack/react-start";
 import { useAtomValue } from "jotai";
 import { DateTime } from "luxon";
 import {
@@ -14,7 +13,6 @@ import {
 
 import { filterAtom, isUseFilterAtom } from "../atoms/filter";
 
-import { cacheMiddleware } from "../utils/cacheMiddleware";
 import { fetchOptions } from "./custom/utils";
 import { itemFetcher, itemKey } from "./item";
 
@@ -23,26 +21,14 @@ export const rankingKey = (type: NarouRankingType, date: string) =>
 export const rankingFetcher: QueryFunction<
 	NarouRankingResult[],
 	ReturnType<typeof rankingKey>
-> = async ({ queryKey: [, type, date] }) =>
-	await rankingServerFn({ data: { type, date } });
-
-const rankingServerFn = createServerFn({ method: "GET" })
-	.middleware([
-		cacheMiddleware({
-			// 過去のランキングは全く変わらないはずなので長めにキャッシュする
-			maxAge: 60 * 60 * 24 * 30, // 30 日
-			sMaxAge: 60 * 60 * 24 * 30, // 30 日
-		}),
-	])
-	.inputValidator((data: { type: NarouRankingType; date: string }) => data)
-	.handler(async ({ data: { type, date } }) => {
-		const dateValue = DateTime.fromISO(date, { zone: "Asia/Tokyo" })
-			.setZone("UTC", { keepLocalTime: true })
-			.toJSDate();
-		return await ranking().date(dateValue).type(type).execute({
-			fetchOptions, // TTLは伸ばしていないが、未生成のランキングのエラーをキャッシュするのは避けたい
-		});
+> = async ({ queryKey: [, type, date] }) => {
+	const dateValue = DateTime.fromISO(date, { zone: "Asia/Tokyo" })
+		.setZone("UTC", { keepLocalTime: true })
+		.toJSDate();
+	return await ranking().date(dateValue).type(type).execute({
+		fetchOptions,
 	});
+};
 
 export function useRanking(type: NarouRankingType, date: string) {
 	const { data } = useSuspenseQuery({

--- a/src/modules/data/ranking.ts
+++ b/src/modules/data/ranking.ts
@@ -25,19 +25,22 @@ export const rankingFetcher: QueryFunction<
 	const dateValue = DateTime.fromISO(date, { zone: "Asia/Tokyo" })
 		.setZone("UTC", { keepLocalTime: true })
 		.toJSDate();
-	return await ranking().date(dateValue).type(type).execute({
-		fetchOptions: {
-			...fetchOptions,
-			cf: {
-				cacheTtlByStatus: {
-					"200-299": 60 * 60 * 24 * 30, // 30 日
-					404: 1,
-					"500-599": 0,
+	return await ranking()
+		.date(dateValue)
+		.type(type)
+		.execute({
+			fetchOptions: {
+				...fetchOptions,
+				cf: {
+					cacheTtlByStatus: {
+						"200-299": 60 * 60 * 24 * 30, // 30 日
+						404: 1,
+						"500-599": 0,
+					},
+					cacheEverything: true,
 				},
-				cacheEverything: true,
-			},
-		}, // TTLは伸ばしていないが、未生成のランキングのエラーをキャッシュするのは避けたい
-	});
+			}, // TTLは伸ばしていないが、未生成のランキングのエラーをキャッシュするのは避けたい
+		});
 };
 
 export function useRanking(type: NarouRankingType, date: string) {


### PR DESCRIPTION
Replaced `createServerFn` usage with direct calls to the `narou` library, ensuring data is fetched directly on the client side instead of using TanStack Start's server functions. This required refactoring the `DataLoader` callbacks and `QueryFunction` fetchers across all data modules to move the query building and fetching logic out of the server handlers.

Changes included removing `cacheMiddleware` references since they only pertained to the server functions, and relying on `react-query` and `dataloader` for managing client-side caching and batching. Verified the ranking pages render correctly on the client post-refactoring.

---
*PR created automatically by Jules for task [465723415822417967](https://jules.google.com/task/465723415822417967) started by @deflis*