### PR TITLE
🧪 checkAllGenres のテスト追加および parseDateRange のバグ修正

### DIFF
--- a/src/modules/atoms/__tests__/filter.test.ts
+++ b/src/modules/atoms/__tests__/filter.test.ts
@@ -40,25 +40,18 @@ describe("filter utilities", () => {
 		});
 
 		it("相対的な期間文字列 (days) を正しく解析すること", () => {
-			const todayStart = mockNow.startOf("day");
 			const result = parseDateRange("7days");
-			expect(result?.toISODate()).toBe(todayStart.minus({ days: 7 }).toISODate());
+			expect(result?.toISODate()).toBe("2023-12-25");
 		});
 
 		it("相対的な期間文字列 (months) を正しく解析すること", () => {
-			const todayStart = mockNow.startOf("day");
 			const result = parseDateRange("1months");
-			expect(result?.toISODate()).toBe(
-				todayStart.minus({ months: 1 }).toISODate(),
-			);
+			expect(result?.toISODate()).toBe("2023-12-01");
 		});
 
 		it("相対的な期間文字列 (years) を正しく解析すること", () => {
-			const todayStart = mockNow.startOf("day");
 			const result = parseDateRange("1years");
-			expect(result?.toISODate()).toBe(
-				todayStart.minus({ years: 1 }).toISODate(),
-			);
+			expect(result?.toISODate()).toBe("2023-01-01");
 		});
 
 		it("ISO日付文字列を正しく解析すること", () => {

--- a/src/modules/atoms/__tests__/filter.test.ts
+++ b/src/modules/atoms/__tests__/filter.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { checkAllGenres, parseDateRange } from "../filter";
-import { allGenres } from "../../enum/Genre";
 import { DateTime, Settings } from "luxon";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { allGenres } from "../../enum/Genre";
+import { checkAllGenres, parseDateRange } from "../filter";
 
 // タイムゾーンを日本に固定
 Settings.defaultZone = "Asia/Tokyo";
@@ -26,21 +26,38 @@ describe("filter utilities", () => {
 	});
 
 	describe("parseDateRange", () => {
-		const now = DateTime.now().setZone("Asia/Tokyo").startOf("day");
+		const mockNow = DateTime.fromISO("2024-01-01T12:00:00.000Z", {
+			zone: "Asia/Tokyo",
+		});
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(mockNow.toJSDate());
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		const todayStart = mockNow.startOf("day");
 
 		it("相対的な期間文字列 (days) を正しく解析すること", () => {
 			const result = parseDateRange("7days");
-			expect(result?.toISODate()).toBe(now.minus({ days: 7 }).toISODate());
+			expect(result?.toISODate()).toBe(todayStart.minus({ days: 7 }).toISODate());
 		});
 
 		it("相対的な期間文字列 (months) を正しく解析すること", () => {
 			const result = parseDateRange("1months");
-			expect(result?.toISODate()).toBe(now.minus({ months: 1 }).toISODate());
+			expect(result?.toISODate()).toBe(
+				todayStart.minus({ months: 1 }).toISODate(),
+			);
 		});
 
 		it("相対的な期間文字列 (years) を正しく解析すること", () => {
 			const result = parseDateRange("1years");
-			expect(result?.toISODate()).toBe(now.minus({ years: 1 }).toISODate());
+			expect(result?.toISODate()).toBe(
+				todayStart.minus({ years: 1 }).toISODate(),
+			);
 		});
 
 		it("ISO日付文字列を正しく解析すること", () => {

--- a/src/modules/atoms/__tests__/filter.test.ts
+++ b/src/modules/atoms/__tests__/filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { checkAllGenres, parseDateRange } from "../filter";
 import { allGenres } from "../../enum/Genre";
 import { DateTime, Settings } from "luxon";

--- a/src/modules/atoms/__tests__/filter.test.ts
+++ b/src/modules/atoms/__tests__/filter.test.ts
@@ -39,14 +39,14 @@ describe("filter utilities", () => {
 			vi.useRealTimers();
 		});
 
-		const todayStart = mockNow.startOf("day");
-
 		it("相対的な期間文字列 (days) を正しく解析すること", () => {
+			const todayStart = mockNow.startOf("day");
 			const result = parseDateRange("7days");
 			expect(result?.toISODate()).toBe(todayStart.minus({ days: 7 }).toISODate());
 		});
 
 		it("相対的な期間文字列 (months) を正しく解析すること", () => {
+			const todayStart = mockNow.startOf("day");
 			const result = parseDateRange("1months");
 			expect(result?.toISODate()).toBe(
 				todayStart.minus({ months: 1 }).toISODate(),
@@ -54,6 +54,7 @@ describe("filter utilities", () => {
 		});
 
 		it("相対的な期間文字列 (years) を正しく解析すること", () => {
+			const todayStart = mockNow.startOf("day");
 			const result = parseDateRange("1years");
 			expect(result?.toISODate()).toBe(
 				todayStart.minus({ years: 1 }).toISODate(),

--- a/src/modules/atoms/__tests__/filter.test.ts
+++ b/src/modules/atoms/__tests__/filter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { checkAllGenres, parseDateRange } from "../filter";
+import { allGenres } from "../../enum/Genre";
+import { DateTime, Settings } from "luxon";
+
+// タイムゾーンを日本に固定
+Settings.defaultZone = "Asia/Tokyo";
+
+describe("filter utilities", () => {
+	describe("checkAllGenres", () => {
+		it("すべてのジャンルが含まれている場合に true を返すこと", () => {
+			expect(checkAllGenres([...allGenres])).toBe(true);
+		});
+
+		it("ジャンルが不足している場合に false を返すこと", () => {
+			expect(checkAllGenres([allGenres[0]])).toBe(false);
+		});
+
+		it("空の配列の場合に false を返すこと", () => {
+			expect(checkAllGenres([])).toBe(false);
+		});
+
+		it("重複していてもすべてのジャンルが含まれていれば true を返すこと", () => {
+			expect(checkAllGenres([...allGenres, allGenres[0]])).toBe(true);
+		});
+	});
+
+	describe("parseDateRange", () => {
+		const now = DateTime.now().setZone("Asia/Tokyo").startOf("day");
+
+		it("相対的な期間文字列 (days) を正しく解析すること", () => {
+			const result = parseDateRange("7days");
+			expect(result?.toISODate()).toBe(now.minus({ days: 7 }).toISODate());
+		});
+
+		it("相対的な期間文字列 (months) を正しく解析すること", () => {
+			const result = parseDateRange("1months");
+			expect(result?.toISODate()).toBe(now.minus({ months: 1 }).toISODate());
+		});
+
+		it("相対的な期間文字列 (years) を正しく解析すること", () => {
+			const result = parseDateRange("1years");
+			expect(result?.toISODate()).toBe(now.minus({ years: 1 }).toISODate());
+		});
+
+		it("ISO日付文字列を正しく解析すること", () => {
+			const isoString = "2023-01-01T00:00:00.000Z";
+			const result = parseDateRange(isoString);
+			expect(result?.isValid).toBe(true);
+			expect(result?.toISODate()).toBe("2023-01-01");
+		});
+
+		it("無効な入力に対して undefined を返すこと", () => {
+			expect(parseDateRange(undefined)).toBeUndefined();
+			expect(parseDateRange("invalid-date")).toBeUndefined();
+		});
+	});
+});

--- a/src/modules/atoms/filter.ts
+++ b/src/modules/atoms/filter.ts
@@ -53,14 +53,14 @@ export function parseDateRange(raw: string | undefined): DateTime | undefined {
 			return DateTime.now()
 				.setZone("Asia/Tokyo")
 				.startOf("day")
-				.minus({ months: years });
+				.minus({ years });
 		}
 	}
 	const date = raw ? DateTime.fromISO(raw, { zone: "Asia/Tokyo" }) : undefined;
 	return date?.isValid ? date : undefined;
 }
 
-function checkAllGenres(genres: Genre[]): boolean {
+export function checkAllGenres(genres: Genre[]): boolean {
 	return allGenres.every((genre) => genres.includes(genre));
 }
 


### PR DESCRIPTION
### 🧪 Testing Improvement Task

#### 🎯 What
`src/modules/atoms/filter.ts` に含まれる `checkAllGenres` ユーティリティ関数のテストが不足していたため、新規にテストを追加しました。また、同ファイル内の `parseDateRange` 関数において、`years` 指定時に誤って `months` を減算していたバグを修正しました。

#### 📊 Coverage
- `checkAllGenres`: すべてのジャンルが含まれている場合、不足している場合、空の配列、重複がある場合の挙動をテスト。
- `parseDateRange`: 相対的な期間（days, months, years）、ISO日付文字列、無効な入力の解析結果を詳細に検証するテストを追加。

#### ✨ Result
- テストカバレッジの向上により、フィルタリングロジックの信頼性が向上しました。
- 日付解析における `years` のバグが修正され、正しい期間フィルタリングが可能になりました。


---
*PR created automatically by Jules for task [10687149232048567892](https://jules.google.com/task/10687149232048567892) started by @deflis*