### PR TITLE
persisterの日付復元処理にISO形式ガード追加

### DIFF
--- a/src/modules/utils/persister.ts
+++ b/src/modules/utils/persister.ts
@@ -6,12 +6,13 @@ import { DateTime } from "luxon";
  */
 function reviver(key: string, value: unknown): unknown {
 	if (typeof value === "string") {
-		if (!/^\d{4}-\d{2}-\d{2}(?:[T\s].*)?$/.test(value)) {
+		try {
+			const date = DateTime.fromISO(value, { zone: "Asia/Tokyo" });
+			if (date.isValid) {
+				return date;
+			}
+		} catch {
 			return value;
-		}
-		const date = DateTime.fromISO(value, { zone: "Asia/Tokyo" });
-		if (date.isValid) {
-			return date;
 		}
 	}
 	return value;

--- a/src/modules/utils/persister.ts
+++ b/src/modules/utils/persister.ts
@@ -6,6 +6,9 @@ import { DateTime } from "luxon";
  */
 function reviver(key: string, value: unknown): unknown {
 	if (typeof value === "string") {
+		if (!/^\d{4}-\d{2}-\d{2}(?:[T\s].*)?$/.test(value)) {
+			return value;
+		}
 		const date = DateTime.fromISO(value, { zone: "Asia/Tokyo" });
 		if (date.isValid) {
 			return date;


### PR DESCRIPTION
### Motivation
- ローカルストレージ復元時に相対日時文字列（例: `2days`）を `DateTime.fromISO` に渡すと `throwOnInvalid` の設定下で例外になる問題を回避するため。変更箇所は `src/modules/utils/persister.ts`。

### Description
- `reviver` に ISO 形式らしい文字列かを判定する正規表現チェックを追加し、`YYYY-MM-DD` で始まらない文字列はそのまま返すようにした。 
- 日付であれば従来どおり `DateTime.fromISO` でパースして `DateTime` を返す実装は維持している。

### Testing
- 型チェックを実行して問題ないことを確認: `pnpm typecheck`（成功）。
- リントを実行して問題ないことを確認: `pnpm lint`（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d940431dfc8329a5c6628cf1b5c419)