### PR TITLE
CIでの失敗ログをPRへ自動表示

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,94 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Biome Linting
-        run: pnpm run lint
+        id: lint
+        continue-on-error: true
+        run: |
+          pnpm run lint 2>&1 | tee lint.log
 
       - name: Run Typecheck
-        run: pnpm run typecheck
+        id: typecheck
+        continue-on-error: true
+        run: |
+          pnpm run typecheck 2>&1 | tee typecheck.log
 
       - name: Run Tests
-        run: pnpm test
+        id: test
+        continue-on-error: true
+        run: |
+          pnpm test 2>&1 | tee test.log
+
+      - name: PRに失敗内容をコメント
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        env:
+          LINT_RESULT: ${{ steps.lint.outcome }}
+          TYPECHECK_RESULT: ${{ steps.typecheck.outcome }}
+          TEST_RESULT: ${{ steps.test.outcome }}
+        with:
+          script: |
+            const fs = require("node:fs");
+
+            const readTail = (path, max = 80) => {
+              if (!fs.existsSync(path)) return "_ログなし_";
+              const lines = fs.readFileSync(path, "utf8").split("\n");
+              return lines.slice(-max).join("\n").trim() || "_ログなし_";
+            };
+
+            const checks = [
+              { name: "Biome Linting", result: process.env.LINT_RESULT, log: "lint.log" },
+              { name: "Typecheck", result: process.env.TYPECHECK_RESULT, log: "typecheck.log" },
+              { name: "Tests", result: process.env.TEST_RESULT, log: "test.log" },
+            ];
+
+            const failures = checks.filter((c) => c.result !== "success");
+            const marker = "<!-- ci-error-report -->";
+            let body = `${marker}\n## CI実行結果\n`;
+
+            if (failures.length === 0) {
+              body += "\n✅ すべてのチェックが成功しました。";
+            } else {
+              body += "\n❌ 失敗したチェックがあります。\n";
+              for (const failure of failures) {
+                const tail = readTail(failure.log);
+                body += `\n### ${failure.name}\n`;
+                body += "```text\n";
+                body += `${tail}\n`;
+                body += "```\n";
+              }
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: ワークフロー失敗判定
+        if: always()
+        run: |
+          failed=0
+          [ "${{ steps.lint.outcome }}" = "success" ] || failed=1
+          [ "${{ steps.typecheck.outcome }}" = "success" ] || failed=1
+          [ "${{ steps.test.outcome }}" = "success" ] || failed=1
+          exit $failed


### PR DESCRIPTION
### Motivation
- GitHub Actions の失敗内容を PR 上で直接確認できるようにして、Actions ページへ移動せずにエラー内容を把握できるようにする目的。 

### Description
- `lint` / `typecheck` / `test` を `continue-on-error: true` にして各コマンドの標準出力を `tee` でそれぞれ `lint.log` / `typecheck.log` / `test.log` に保存するようにした。 
- PR イベント時に `actions/github-script` を使い、各ログの末尾（最大80行）を収集してマーカー `<!-- ci-error-report -->` を含むコメントとして PR に投稿・既存コメントは更新する処理を追加した。 
- 最後に集約ステップで各チェックの結果を確認し、いずれかが失敗ならジョブ全体を失敗として終了する判定ステップを追加した。 

### Testing
- `pnpm run lint` を実行して成功を確認済み（`biome check` 実行、98ファイルチェック、問題なし）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94093e56c8329a1259fa92f223718)