### PR TITLE
CIチェックのエラー内容をChecksに表示する設定追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Biome Linting
-        run: pnpm run lint
+        run: pnpm biome check . --reporter=github
 
       - name: Run Typecheck
-        run: pnpm run typecheck
+        run: pnpm tsc --noEmit --pretty false
 
       - name: Run Tests
-        run: pnpm test
+        run: pnpm test -- --reporter=github-actions --reporter=default


### PR DESCRIPTION
### Motivation
- GitHub Actions の Checks 上で Lint / Typecheck / Test の失敗内容が注釈やレポーター経由で見えるようにするため。  

### Description
- CI ワークフロー（`.github/workflows/ci.yml`）を更新して、Biome を `pnpm biome check . --reporter=github` に、TypeScript を `pnpm tsc --noEmit --pretty false` に、テストを `pnpm test -- --reporter=github-actions --reporter=default` に変更した。  

### Testing
- 自動検査として `pnpm -s run typecheck` が成功し、`pnpm -s test` が実行されて `Test Files 6 passed` と `Tests 80 passed` で成功した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d942831c20832981ea726b254aa528)