### PR TITLE
CI修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,26 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Biome Linting
-        run: pnpm biome check . --reporter=github
+        id: lint
+        run: pnpm exec biome ci . --reporter=github
+        continue-on-error: true
 
       - name: Run Typecheck
-        run: pnpm tsc --noEmit --pretty false
+        id: typecheck
+        if: ${{ always() }}
+        run: pnpm exec tsc --noEmit --pretty false
+        continue-on-error: true
 
       - name: Run Tests
-        run: pnpm test -- --reporter=github-actions --reporter=default
+        id: test
+        if: ${{ always() }}
+        run: pnpm exec vitest run --reporter=github-actions --reporter=default
+        continue-on-error: true
+
+      - name: Fail if any checks failed
+        if: ${{ always() && (steps.lint.outcome == 'failure' || steps.typecheck.outcome == 'failure' || steps.test.outcome == 'failure') }}
+        run: |
+          echo "One or more checks failed."
+          echo "lint=${{ steps.lint.outcome }}, typecheck=${{ steps.typecheck.outcome }}, test=${{ steps.test.outcome }}"
+          exit 1
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: true
 
       - name: Fail if any checks failed
-        if: ${{ always() && (steps.lint.outcome == 'failure' || steps.typecheck.outcome == 'failure' || steps.test.outcome == 'failure') }}
+        if: ${{ always() && (steps.lint.outcome != 'success' || steps.typecheck.outcome != 'success' || steps.test.outcome != 'success') }}
         run: |
           echo "One or more checks failed."
           echo "lint=${{ steps.lint.outcome }}, typecheck=${{ steps.typecheck.outcome }}, test=${{ steps.test.outcome }}"


### PR DESCRIPTION
This pull request updates the CI workflow to improve error handling and reporting for linting, type checking, and testing steps. Each step now continues on error, but a final step ensures the workflow fails if any check did not succeed. The most important changes are:

**CI Workflow Improvements:**

* Each of the linting (`biome`), type checking (`tsc`), and testing (`vitest`) steps now has an `id`, uses `pnpm exec`, and sets `continue-on-error: true`, allowing the workflow to proceed even if one step fails.
* Added a new "Fail if any checks failed" step at the end, which explicitly fails the workflow if any of the previous steps did not succeed, ensuring proper failure reporting.
* The test runner was switched from `pnpm test` to `pnpm exec vitest run`, standardizing on `vitest` for test execution.
* All steps now use the `--reporter=github-actions` option for improved integration with GitHub Actions.