### PR TITLE
フィルターモジュールのバリデーション機能を追加

### DIFF
--- a/src/components/ui/custom/CustomRankingForm.tsx
+++ b/src/components/ui/custom/CustomRankingForm.tsx
@@ -7,6 +7,8 @@ import { FaCog, FaSearch, FaTimes } from "react-icons/fa";
 
 import {
 	type FilterConfig,
+	isCustomDateString,
+	isRelativeTermString,
 	type TermStrings,
 	parseDateRange,
 } from "../../../modules/atoms/filter";
@@ -117,10 +119,11 @@ function getDefaultValues({
 			},
 		},
 		firstUpdate: {
-			term: DateTime.fromISO(firstUpdateRaw ?? "", { zone: "Asia/Tokyo" })
-				.isValid
+			term: isCustomDateString(firstUpdateRaw)
 				? "custom"
-				: ((firstUpdateRaw as TermStrings) ?? "none"),
+				: isRelativeTermString(firstUpdateRaw)
+					? firstUpdateRaw
+					: "none",
 			begin:
 				firstUpdate?.toISODate() ??
 				DateTime.now().setZone("Asia/Tokyo").toISODate(),

--- a/src/components/ui/custom/CustomRankingForm.tsx
+++ b/src/components/ui/custom/CustomRankingForm.tsx
@@ -8,8 +8,7 @@ import { FaCog, FaSearch, FaTimes } from "react-icons/fa";
 import {
 	type FilterConfig,
 	type TermStrings,
-	isCustomDateString,
-	isRelativeTermString,
+	getTermFromRaw,
 	parseDateRange,
 } from "../../../modules/atoms/filter";
 import { allGenres } from "../../../modules/enum/Genre";
@@ -119,11 +118,7 @@ function getDefaultValues({
 			},
 		},
 		firstUpdate: {
-			term: isCustomDateString(firstUpdateRaw)
-				? "custom"
-				: isRelativeTermString(firstUpdateRaw)
-					? firstUpdateRaw
-					: "none",
+			term: getTermFromRaw(firstUpdateRaw),
 			begin:
 				firstUpdate?.toISODate() ??
 				DateTime.now().setZone("Asia/Tokyo").toISODate(),

--- a/src/components/ui/custom/CustomRankingForm.tsx
+++ b/src/components/ui/custom/CustomRankingForm.tsx
@@ -7,9 +7,9 @@ import { FaCog, FaSearch, FaTimes } from "react-icons/fa";
 
 import {
 	type FilterConfig,
+	type TermStrings,
 	isCustomDateString,
 	isRelativeTermString,
-	type TermStrings,
 	parseDateRange,
 } from "../../../modules/atoms/filter";
 import { allGenres } from "../../../modules/enum/Genre";
@@ -204,7 +204,7 @@ function formatDateRange(raw: string | TermStrings | undefined): string {
 		return "";
 	}
 }
-	
+
 const DisableCustomRankingForm: React.FC<{
 	params: CustomRankingParams;
 }> = React.memo(function DisableCustomRankingFormBase({

--- a/src/components/ui/custom/CustomRankingForm.tsx
+++ b/src/components/ui/custom/CustomRankingForm.tsx
@@ -193,14 +193,18 @@ function formatDateRange(raw: string | TermStrings | undefined): string {
 	}
 
 	// ISO日付形式の処理
-	const date = DateTime.fromISO(raw, { zone: "Asia/Tokyo" });
-	if (!date.isValid) {
+	try {
+		const date = DateTime.fromISO(raw, { zone: "Asia/Tokyo" });
+		if (!date.isValid) {
+			return "";
+		}
+
+		return date.toFormat("yyyy年MM月dd日");
+	} catch {
 		return "";
 	}
-
-	return date.toFormat("yyyy年MM月dd日");
 }
-
+	
 const DisableCustomRankingForm: React.FC<{
 	params: CustomRankingParams;
 }> = React.memo(function DisableCustomRankingFormBase({

--- a/src/components/ui/custom/R18RankingForm.tsx
+++ b/src/components/ui/custom/R18RankingForm.tsx
@@ -7,7 +7,8 @@ import { FaCog, FaSearch, FaTimes } from "react-icons/fa";
 
 import {
 	type FilterConfig,
-	type TermStrings,
+	isCustomDateString,
+	isRelativeTermString,
 	parseDateRange,
 } from "../../../modules/atoms/filter";
 import type { R18RankingParams } from "../../../modules/interfaces/CustomRankingParams";
@@ -152,10 +153,11 @@ function getDefaultValues({
 			},
 		},
 		firstUpdate: {
-			term: DateTime.fromISO(firstUpdateRaw ?? "", { zone: "Asia/Tokyo" })
-				.isValid
+			term: isCustomDateString(firstUpdateRaw)
 				? "custom"
-				: ((firstUpdateRaw as TermStrings) ?? "none"),
+				: isRelativeTermString(firstUpdateRaw)
+					? firstUpdateRaw
+					: "none",
 			begin:
 				firstUpdate?.toISODate() ??
 				DateTime.now().setZone("Asia/Tokyo").toISODate(),

--- a/src/components/ui/custom/R18RankingForm.tsx
+++ b/src/components/ui/custom/R18RankingForm.tsx
@@ -7,8 +7,7 @@ import { FaCog, FaSearch, FaTimes } from "react-icons/fa";
 
 import {
 	type FilterConfig,
-	isCustomDateString,
-	isRelativeTermString,
+	getTermFromRaw,
 	parseDateRange,
 } from "../../../modules/atoms/filter";
 import type { R18RankingParams } from "../../../modules/interfaces/CustomRankingParams";
@@ -153,11 +152,7 @@ function getDefaultValues({
 			},
 		},
 		firstUpdate: {
-			term: isCustomDateString(firstUpdateRaw)
-				? "custom"
-				: isRelativeTermString(firstUpdateRaw)
-					? firstUpdateRaw
-					: "none",
+			term: getTermFromRaw(firstUpdateRaw),
 			begin:
 				firstUpdate?.toISODate() ??
 				DateTime.now().setZone("Asia/Tokyo").toISODate(),

--- a/src/modules/atoms/__tests__/filter.test.ts
+++ b/src/modules/atoms/__tests__/filter.test.ts
@@ -65,5 +65,16 @@ describe("filter utilities", () => {
 			expect(parseDateRange(undefined)).toBeUndefined();
 			expect(parseDateRange("invalid-date")).toBeUndefined();
 		});
+
+		it("throwOnInvalid=true でも無効な入力で例外を投げないこと", () => {
+			const prevThrowOnInvalid = Settings.throwOnInvalid;
+			Settings.throwOnInvalid = true;
+			try {
+				expect(() => parseDateRange("invalid-date")).not.toThrow();
+				expect(parseDateRange("invalid-date")).toBeUndefined();
+			} finally {
+				Settings.throwOnInvalid = prevThrowOnInvalid;
+			}
+		});
 	});
 });

--- a/src/modules/atoms/__tests__/filter.test.ts
+++ b/src/modules/atoms/__tests__/filter.test.ts
@@ -1,7 +1,7 @@
 import { DateTime, Settings } from "luxon";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { allGenres } from "../../enum/Genre";
-import { checkAllGenres, parseDateRange } from "../filter";
+import { checkAllGenres, getTermFromRaw, parseDateRange } from "../filter";
 
 // タイムゾーンを日本に固定
 Settings.defaultZone = "Asia/Tokyo";
@@ -75,6 +75,21 @@ describe("filter utilities", () => {
 			} finally {
 				Settings.throwOnInvalid = prevThrowOnInvalid;
 			}
+		});
+	});
+
+	describe("getTermFromRaw", () => {
+		it("相対termはそのまま返すこと", () => {
+			expect(getTermFromRaw("7days")).toBe("7days");
+		});
+
+		it("ISO日付はcustomを返すこと", () => {
+			expect(getTermFromRaw("2023-01-01T00:00:00.000Z")).toBe("custom");
+		});
+
+		it("無効値はnoneを返すこと", () => {
+			expect(getTermFromRaw(undefined)).toBe("none");
+			expect(getTermFromRaw("invalid-date")).toBe("none");
 		});
 	});
 });

--- a/src/modules/atoms/filter.ts
+++ b/src/modules/atoms/filter.ts
@@ -25,6 +25,25 @@ export const firstUpdateAtom = atom((get) =>
 	parseDateRange(get(firstUpdateRawAtom)),
 );
 
+const relativeTermPattern = /^\d+(days|months|years)$/;
+
+export function isRelativeTermString(
+	raw: string | undefined,
+): raw is TermStrings {
+	return !!raw && relativeTermPattern.test(raw);
+}
+
+export function isCustomDateString(raw: string | undefined): boolean {
+	if (!raw || isRelativeTermString(raw)) {
+		return false;
+	}
+	try {
+		return DateTime.fromISO(raw, { zone: "Asia/Tokyo" }).isValid;
+	} catch {
+		return false;
+	}
+}
+
 export function parseDateRange(raw: string | undefined): DateTime | undefined {
 	if (!raw) {
 		return undefined;
@@ -56,8 +75,12 @@ export function parseDateRange(raw: string | undefined): DateTime | undefined {
 				.minus({ years });
 		}
 	}
-	const date = raw ? DateTime.fromISO(raw, { zone: "Asia/Tokyo" }) : undefined;
-	return date?.isValid ? date : undefined;
+	try {
+		const date = DateTime.fromISO(raw, { zone: "Asia/Tokyo" });
+		return date.isValid ? date : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 export function checkAllGenres(genres: Genre[]): boolean {
@@ -139,11 +162,11 @@ export const filterConfigAtom = atom<FilterConfig, [FilterConfig], void>(
 				},
 			},
 			firstUpdate: {
-				term:
-					firstUpdateRaw &&
-					DateTime.fromISO(firstUpdateRaw, { zone: "Asia/Tokyo" }).isValid
-						? "custom"
-						: ((firstUpdateRaw as TermStrings) ?? "none"),
+				term: isCustomDateString(firstUpdateRaw)
+					? "custom"
+					: isRelativeTermString(firstUpdateRaw)
+						? firstUpdateRaw
+						: "none",
 				begin:
 					firstUpdate?.toISODate() ??
 					DateTime.now().setZone("Asia/Tokyo").toISODate(),

--- a/src/modules/atoms/filter.ts
+++ b/src/modules/atoms/filter.ts
@@ -44,6 +44,18 @@ export function isCustomDateString(raw: string | undefined): boolean {
 	}
 }
 
+export function getTermFromRaw(
+	raw: string | undefined,
+): TermStrings | "custom" | "none" {
+	if (isCustomDateString(raw)) {
+		return "custom";
+	}
+	if (isRelativeTermString(raw)) {
+		return raw;
+	}
+	return "none";
+}
+
 export function parseDateRange(raw: string | undefined): DateTime | undefined {
 	if (!raw) {
 		return undefined;
@@ -162,11 +174,7 @@ export const filterConfigAtom = atom<FilterConfig, [FilterConfig], void>(
 				},
 			},
 			firstUpdate: {
-				term: isCustomDateString(firstUpdateRaw)
-					? "custom"
-					: isRelativeTermString(firstUpdateRaw)
-						? firstUpdateRaw
-						: "none",
+				term: getTermFromRaw(firstUpdateRaw),
 				begin:
 					firstUpdate?.toISODate() ??
 					DateTime.now().setZone("Asia/Tokyo").toISODate(),

--- a/src/routes/ranking/{-$type}/{-$date}.tsx
+++ b/src/routes/ranking/{-$type}/{-$date}.tsx
@@ -107,8 +107,8 @@ function RankingPage() {
 
 	const handleDateCommit = useCallback(
 		(value: string) => {
-			const newDate = DateTime.fromISO(value, { zone: "Asia/Tokyo" });
-			if (newDate.isValid) {
+			try {
+				const newDate = DateTime.fromISO(value, { zone: "Asia/Tokyo" });
 				navigate({
 					to: "/ranking/{-$type}/{-$date}",
 					params: (prev) => ({
@@ -117,6 +117,8 @@ function RankingPage() {
 						date: newDate.toISODate(),
 					}),
 				});
+			} catch {
+				// 無効な日付の場合は何もしない
 			}
 		},
 		[type, navigate],


### PR DESCRIPTION
- isCustomDateStringおよびisRelativeTermString関数を追加
- parseDateRange関数のエラーハンドリングを改善
- CustomRankingFormおよびR18RankingFormでのfirstUpdateの処理を修正
- filter.test.tsに無効な入力に対するテストを追加