### PR TITLE
検索経由でのランキングに関連するRouteコンポーネントにSSR無効化を追加

### DIFF
--- a/src/routes/custom/{-$type}.tsx
+++ b/src/routes/custom/{-$type}.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/modules/utils/parseSearch";
 
 export const Route = createFileRoute("/custom/{-$type}")({
+	ssr: false,
 	validateSearch: (search: Record<string, unknown>): CustomRankingSearch => {
 		return {
 			keyword: search.keyword as string | undefined,

--- a/src/routes/r18/index.tsx
+++ b/src/routes/r18/index.tsx
@@ -13,6 +13,7 @@ import {
 import { parseR18RankingParams } from "@/modules/utils/parseSearch";
 
 export const Route = createFileRoute("/r18/")({
+	ssr: false,
 	validateSearch: (search: Record<string, unknown>): R18RankingSearch => {
 		return {
 			keyword: search.keyword as string | undefined,

--- a/src/routes/r18/ranking/{-$type}.tsx
+++ b/src/routes/r18/ranking/{-$type}.tsx
@@ -14,6 +14,7 @@ import {
 import { parseR18RankingParams } from "@/modules/utils/parseSearch";
 
 export const Route = createFileRoute("/r18/ranking/{-$type}")({
+	ssr: false,
 	validateSearch: (search: Record<string, unknown>): R18RankingSearch => {
 		return {
 			keyword: search.keyword as string | undefined,


### PR DESCRIPTION
- /custom/{-$type}のRouteでssrをfalseに設定
- /r18/のRouteでssrをfalseに設定
- /r18/ranking/{-$type}のRouteでssrをfalseに設定