### PR TITLE
loaderのデータ取得でprefetchQueryではなくensureQueryDataを使用するように変更

### DIFF
--- a/src/modules/data/custom.ts
+++ b/src/modules/data/custom.ts
@@ -46,11 +46,10 @@ export const prefetchCustomRanking = async (
 	params: CustomRankingParams,
 	page: number,
 ) => {
-	await queryClient.prefetchQuery({
+	const ranking = await queryClient.ensureQueryData({
 		queryKey: [params, page],
 		queryFn: getCustomRankingQueryFn(queryClient),
 	});
-	const ranking = queryClient.getQueryData<RankingData[]>([params, page]);
 	await prefetchRankingDetail(queryClient, ranking?.map((x) => x.ncode) ?? []);
 };
 

--- a/src/modules/data/prefetch.ts
+++ b/src/modules/data/prefetch.ts
@@ -20,13 +20,10 @@ export const prefetchRanking = async (
 	date: DateTime,
 ) => {
 	const normalizedDate = convertDate(date, type).toISODate();
-	await queryClient.prefetchQuery({
+	const ranking = await queryClient.ensureQueryData({
 		queryKey: rankingKey(type, normalizedDate),
 		queryFn: rankingFetcher,
 	});
-	const ranking = queryClient.getQueryData<NarouRankingResult[]>(
-		rankingKey(type, normalizedDate),
-	);
 	await prefetchRankingDetail(
 		queryClient,
 		ranking?.slice(0, 10).map((x) => x.ncode) ?? [],
@@ -39,7 +36,7 @@ export const prefetchRankingDetail = async (
 ) => {
 	await Promise.all(
 		ncodes.map(async (ncode) =>
-			queryClient.prefetchQuery({
+			queryClient.ensureQueryData({
 				queryKey: itemKey(ncode),
 				queryFn: itemFetcher,
 			}),
@@ -52,15 +49,15 @@ export const prefetchDetail = async (
 	ncode: string,
 ) => {
 	await Promise.all([
-		queryClient.prefetchQuery({
+		queryClient.ensureQueryData({
 			queryKey: itemKey(ncode),
 			queryFn: itemFetcher,
 		}),
-		queryClient.prefetchQuery({
+		queryClient.ensureQueryData({
 			queryKey: itemDetailKey(ncode),
 			queryFn: itemDetailFetcher,
 		}),
-		queryClient.prefetchQuery({
+		queryClient.ensureQueryData({
 			queryKey: itemRankingHistoryKey(ncode),
 			queryFn: itemRankingHistoryFetcher,
 		}),

--- a/src/modules/data/prefetch.ts
+++ b/src/modules/data/prefetch.ts
@@ -34,7 +34,7 @@ export const prefetchRankingDetail = async (
 	queryClient: QueryClient,
 	ncodes: string[],
 ) => {
-	await Promise.all(
+	await Promise.allSettled(
 		ncodes.map(async (ncode) =>
 			queryClient.ensureQueryData({
 				queryKey: itemKey(ncode),
@@ -48,7 +48,7 @@ export const prefetchDetail = async (
 	queryClient: QueryClient,
 	ncode: string,
 ) => {
-	await Promise.all([
+	await Promise.allSettled([
 		queryClient.ensureQueryData({
 			queryKey: itemKey(ncode),
 			queryFn: itemFetcher,

--- a/src/modules/data/r18item.ts
+++ b/src/modules/data/r18item.ts
@@ -48,11 +48,11 @@ export const prefetchR18Detail = async (
 	ncode: string,
 ) => {
 	await Promise.all([
-		queryClient.prefetchQuery({
+		queryClient.ensureQueryData({
 			queryKey: itemKey(ncode),
 			queryFn: itemFetcher,
 		}),
-		queryClient.prefetchQuery({
+		queryClient.ensureQueryData({
 			queryKey: itemDetailKey(ncode),
 			queryFn: itemDetailFetcher,
 		}),

--- a/src/modules/data/r18item.ts
+++ b/src/modules/data/r18item.ts
@@ -47,7 +47,7 @@ export const prefetchR18Detail = async (
 	queryClient: QueryClient,
 	ncode: string,
 ) => {
-	await Promise.all([
+	await Promise.allSettled([
 		queryClient.ensureQueryData({
 			queryKey: itemKey(ncode),
 			queryFn: itemFetcher,

--- a/src/modules/data/r18ranking.ts
+++ b/src/modules/data/r18ranking.ts
@@ -46,11 +46,10 @@ export const prefetchR18Ranking = async (
 	params: R18RankingParams,
 	page: number,
 ) => {
-	await queryClient.prefetchQuery({
+	const ranking = await queryClient.ensureQueryData({
 		queryKey: [params, page],
 		queryFn: getCustomRankingQueryFn(queryClient),
 	});
-	const ranking = queryClient.getQueryData<RankingData[]>([params, page]);
 	await prefetchRankingDetail(queryClient, ranking?.map((x) => x.ncode) ?? []);
 };
 

--- a/src/routes/custom/{-$type}.tsx
+++ b/src/routes/custom/{-$type}.tsx
@@ -56,7 +56,7 @@ export const Route = createFileRoute("/custom/{-$type}")({
 		deps: { search },
 	}) => {
 		const params = parseCustomRankingParams(type, search);
-		await prefetchCustomRanking(queryClient, params, 1);
+		prefetchCustomRanking(queryClient, params, 1);
 	},
 	component: CustomRankingPage,
 	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),

--- a/src/routes/detail/$ncode.tsx
+++ b/src/routes/detail/$ncode.tsx
@@ -11,7 +11,7 @@ import {
 export const Route = createFileRoute("/detail/$ncode")({
 	ssr: false,
 	loader: async ({ context: { queryClient }, params: { ncode } }) => {
-		await prefetchDetail(queryClient, ncode);
+		prefetchDetail(queryClient, ncode);
 	},
 	component: DetailPage,
 	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),

--- a/src/routes/r18/detail/$ncode.tsx
+++ b/src/routes/r18/detail/$ncode.tsx
@@ -11,7 +11,7 @@ import {
 export const Route = createFileRoute("/r18/detail/$ncode")({
 	ssr: false,
 	loader: async ({ context: { queryClient }, params: { ncode } }) => {
-		await prefetchR18Detail(queryClient, ncode);
+		prefetchR18Detail(queryClient, ncode);
 	},
 	component: R18DetailPage,
 	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),

--- a/src/routes/r18/index.tsx
+++ b/src/routes/r18/index.tsx
@@ -33,7 +33,7 @@ export const Route = createFileRoute("/r18/")({
 	loaderDeps: ({ search }) => ({ search }),
 	loader: async ({ context: { queryClient }, deps: { search } }) => {
 		const params = parseR18RankingParams(undefined, search);
-		await prefetchR18Ranking(queryClient, params, 1);
+		prefetchR18Ranking(queryClient, params, 1);
 	},
 	component: R18RankingPageWrapper,
 	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),

--- a/src/routes/r18/ranking/{-$type}.tsx
+++ b/src/routes/r18/ranking/{-$type}.tsx
@@ -38,7 +38,7 @@ export const Route = createFileRoute("/r18/ranking/{-$type}")({
 		deps: { search },
 	}) => {
 		const params = parseR18RankingParams(type, search);
-		await prefetchR18Ranking(queryClient, params, 1);
+		prefetchR18Ranking(queryClient, params, 1);
 	},
 	component: R18RankingPageWrapper,
 	headers: () => createCacheHeaders(MAIN_PAGE_CACHE_OPTIONS),

--- a/src/routes/ranking/{-$type}/{-$date}.tsx
+++ b/src/routes/ranking/{-$type}/{-$date}.tsx
@@ -59,7 +59,7 @@ export const Route = createFileRoute("/ranking/{-$type}/{-$date}")({
 			: DateTime.fromISO(dateParam);
 		const date = convertDate(dt, type);
 
-		await prefetchRanking(queryClient, type, date);
+		prefetchRanking(queryClient, type, date);
 	},
 	component: RankingPage,
 	headers: ({ params: { date } }) => {


### PR DESCRIPTION
- loaderでのデータ事前取得において、`prefetchQuery`の代わりに`ensureQueryData`を使用するよう修正しました。
- `prefetchQuery`に続いて`getQueryData`を実行する冗長なパターンを排除し、`ensureQueryData`の戻り値を直接利用するように変更しました。
- 対象ファイル:
  - `src/modules/data/custom.ts`
  - `src/modules/data/prefetch.ts`
  - `src/modules/data/r18item.ts`
  - `src/modules/data/r18ranking.ts`

---
*PR created automatically by Jules for task [4737095193825458236](https://jules.google.com/task/4737095193825458236) started by @deflis*