### PR TITLE
広告コンポーネントのリファクタリング

### DIFF
--- a/src/components/ui/common/AdRandom.tsx
+++ b/src/components/ui/common/AdRandom.tsx
@@ -1,10 +1,7 @@
 import type React from "react";
-import { useMemo } from "react";
 
-import { AdAmazonWidth } from "./AdAmazon";
 import AdSense from "./AdSense";
 
 export const AdRandomWidth: React.FC = () => {
-	const rand = useMemo(() => Math.random(), []);
-	return rand < 0.5 ? <AdSense /> : <AdAmazonWidth />;
+	return <AdSense />;
 };

--- a/src/components/ui/common/AdSense.tsx
+++ b/src/components/ui/common/AdSense.tsx
@@ -1,7 +1,7 @@
+import clsx from "clsx";
 import { useAtomValue } from "jotai";
 import { useEffect } from "react";
 
-import { useLocation } from "@tanstack/react-router";
 import { adModeAtom } from "../../../modules/atoms/global";
 
 declare global {
@@ -10,12 +10,36 @@ declare global {
 	}
 }
 
-export const AdSense: React.FC = () => {
+interface AdsenseProps {
+	slot?: string;
+	format?: string;
+	responsive?: string;
+	className?: string;
+}
+
+export const AdSense: React.FC<AdsenseProps> = ({
+	slot = "3138091970",
+	format = "auto",
+	responsive = "true",
+	className,
+}) => {
 	const adMode = useAtomValue(adModeAtom);
-	return adMode ? <InnerAdSense /> : null;
+	return adMode ? (
+		<InnerAdSense
+			slot={slot}
+			format={format}
+			responsive={responsive}
+			className={className}
+		/>
+	) : null;
 };
 
-export const InnerAdSense: React.FC = () => {
+const InnerAdSense: React.FC<AdsenseProps> = ({
+	slot = "3138091970",
+	format = "auto",
+	responsive = "true",
+	className,
+}) => {
 	useEffect(() => {
 		if (!window) return;
 		try {
@@ -25,16 +49,19 @@ export const InnerAdSense: React.FC = () => {
 			console.error(e);
 		}
 	}, []);
-	const location = useLocation();
 
 	return (
-		<div className="text-center" key={location.pathname}>
+		<div
+			className={clsx("adsense-container", className)}
+			style={{ minHeight: "100px", overflow: "hidden" }}
+		>
 			<ins
-				className="adsbygoogle block"
-				data-ad-format="fluid"
-				data-ad-layout-key="-fb+5w+4e-db+86"
+				className="adsbygoogle"
+				style={{ display: "block" }}
 				data-ad-client="ca-pub-6809573064811153"
-				data-ad-slot="3138091970"
+				data-ad-slot={slot}
+				data-ad-format={format}
+				data-full-width-responsive={responsive}
 			/>
 		</div>
 	);

--- a/src/components/ui/common/AdSense.tsx
+++ b/src/components/ui/common/AdSense.tsx
@@ -35,9 +35,9 @@ export const AdSense: React.FC<AdsenseProps> = ({
 };
 
 const InnerAdSense: React.FC<AdsenseProps> = ({
-	slot = "3138091970",
-	format = "auto",
-	responsive = "true",
+	slot,
+	format,
+	responsive,
 	className,
 }) => {
 	useEffect(() => {

--- a/src/components/ui/common/AmazonAd.tsx
+++ b/src/components/ui/common/AmazonAd.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+
+interface AmazonAdProps {
+	scriptSrc: string;
+	id?: string;
+}
+
+export function AmazonAd({ scriptSrc, id }: AmazonAdProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (typeof window === "undefined" || !containerRef.current) return;
+
+		if (containerRef.current.querySelector("script")) return;
+
+		const script = document.createElement("script");
+		script.src = scriptSrc;
+		script.type = "text/javascript";
+		script.async = true;
+
+		if (id) {
+			script.id = id;
+		}
+
+		containerRef.current.appendChild(script);
+
+		return () => {
+			if (containerRef.current) {
+				containerRef.current.innerHTML = "";
+			}
+		};
+	}, [scriptSrc, id]);
+
+	return (
+		<div
+			ref={containerRef}
+			className="amazon-ad-container"
+			style={{ minHeight: "250px", display: "flex", justifyContent: "center" }}
+		/>
+	);
+}

--- a/src/components/ui/ranking/CustomRankingRender.tsx
+++ b/src/components/ui/ranking/CustomRankingRender.tsx
@@ -1,16 +1,13 @@
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
 import type React from "react";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Waypoint } from "react-waypoint";
 
-import { adModeAtom } from "../../../modules/atoms/global";
 import { useCustomRanking } from "../../../modules/data/custom";
 import type { CustomRankingParams } from "../../../modules/interfaces/CustomRankingParams";
 import { Button } from "../atoms/Button";
 import { DotLoader } from "../atoms/Loader";
-import { AdAmazonWidth } from "../common/AdAmazon";
 import AdSense from "../common/AdSense";
 import { SelfAd } from "../common/SelfAd";
 
@@ -27,8 +24,6 @@ const InsideRender: React.FC<{
 		setPage((max) => (isTail ? max + 1 : max));
 	}, [setPage, isTail]);
 	const { data } = useCustomRanking(params, page);
-	const adMode = useAtomValue(adModeAtom);
-
 	if (data?.length === 0 || !data) {
 		return page === 1 ? <div className="w-full">データがありません</div> : null;
 	}
@@ -37,11 +32,7 @@ const InsideRender: React.FC<{
 			{data.map((item) => (
 				<RankingItem key={`${item.rank}-${item.ncode}`} item={item} />
 			))}
-			{adMode && (
-				<div className="col-span-full">
-					<AdAmazonWidth />
-				</div>
-			)}
+			<AdSense className="col-span-full" />
 			{isTail && (
 				<Waypoint onEnter={handleMore}>
 					<div className="col-span-full">

--- a/src/components/ui/ranking/R18RankingRender.tsx
+++ b/src/components/ui/ranking/R18RankingRender.tsx
@@ -1,15 +1,12 @@
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Waypoint } from "react-waypoint";
 
-import { adModeAtom } from "../../../modules/atoms/global";
 import { useR18Ranking } from "../../../modules/data/r18ranking";
 import type { R18RankingParams } from "../../../modules/interfaces/CustomRankingParams";
 import { Button } from "../atoms/Button";
 import { DotLoader } from "../atoms/Loader";
-import { AdAmazonWidth } from "../common/AdAmazon";
 import AdSense from "../common/AdSense";
 import { SelfAd } from "../common/SelfAd";
 
@@ -26,8 +23,6 @@ const InsideRender: React.FC<{
 		setPage((max) => (isTail ? max + 1 : max));
 	}, [setPage, isTail]);
 	const { data } = useR18Ranking(params, page);
-	const adMode = useAtomValue(adModeAtom);
-
 	if (data?.length === 0 || !data) {
 		return page === 1 ? <div className="w-full">データがありません</div> : null;
 	}
@@ -36,11 +31,7 @@ const InsideRender: React.FC<{
 			{data.map((item) => (
 				<R18RankingItem key={`${item.rank}-${item.ncode}`} item={item} />
 			))}
-			{adMode && (
-				<div className="col-span-full">
-					<AdAmazonWidth />
-				</div>
-			)}
+			<AdSense className="col-span-full" />
 			{isTail && (
 				<Waypoint onEnter={handleMore}>
 					<div className="col-span-full">

--- a/src/components/ui/ranking/RankingRender.tsx
+++ b/src/components/ui/ranking/RankingRender.tsx
@@ -1,12 +1,9 @@
-import { useAtomValue } from "jotai";
 import type { NarouRankingResult } from "narou";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Waypoint } from "react-waypoint";
 
-import { adModeAtom } from "../../../modules/atoms/global";
 import { chunk } from "../../../modules/utils/chunk";
 import { Button } from "../atoms/Button";
-import { AdAmazonWidth } from "../common/AdAmazon";
 import AdSense from "../common/AdSense";
 import { SelfAd } from "../common/SelfAd";
 
@@ -20,16 +17,10 @@ const ChunkRender: React.FC<{
 	const handleMore = useCallback(() => {
 		setMax((max) => (isTail ? max + 10 : max));
 	}, [setMax, isTail]);
-	const adMode = useAtomValue(adModeAtom);
-
 	return (
 		<>
 			{chunk}
-			{adMode && (
-				<div className="col-span-full	p-auto">
-					<AdAmazonWidth />
-				</div>
-			)}
+			<AdSense className="col-span-full p-auto" />
 			{isTail && (
 				<Waypoint onEnter={handleMore}>
 					<div className="col-span-full px-20 pt-10 pb-20">
@@ -71,25 +62,17 @@ const InsideRender: React.FC<{
 		setMax(10);
 	}, [rankingConstants]);
 
-	const adMode = useAtomValue(adModeAtom);
-
 	return (
 		<div
 			className="w-full grid md:grid-cols-2 p-4 gap-4"
 			suppressHydrationWarning
 		>
-			{adMode && (
-				<div className="col-span-full">
-					<AdSense />
-				</div>
-			)}
+			<AdSense className="col-span-full" />
 			{renderItems}
 			<div className="col-span-full">
 				<SelfAd />
 			</div>
-			<div className="col-span-full">
-				<AdSense />
-			</div>
+			<AdSense className="col-span-full" />
 		</div>
 	);
 };

--- a/src/components/ui/ranking/RankingRender.tsx
+++ b/src/components/ui/ranking/RankingRender.tsx
@@ -20,7 +20,7 @@ const ChunkRender: React.FC<{
 	return (
 		<>
 			{chunk}
-			<AdSense className="col-span-full p-auto" />
+			<AdSense className="col-span-full" />
 			{isTail && (
 				<Waypoint onEnter={handleMore}>
 					<div className="col-span-full px-20 pt-10 pb-20">


### PR DESCRIPTION
- AdRandomWidthコンポーネントからAdAmazonWidthを削除し、AdSenseのみを表示
- AdSenseコンポーネントにプロパティを追加し、InnerAdSenseで使用
- R18RankingRender、CustomRankingRender、RankingRenderでAdAmazonWidthをAdSenseに置き換え
- AmazonAdコンポーネントを新規作成