### PR TITLE
AdSenseコンポーネントのクラス名を修正

### DIFF
--- a/src/components/ui/common/AdSense.tsx
+++ b/src/components/ui/common/AdSense.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from "jotai";
 import { useEffect } from "react";
 
+import { clsx } from "clsx";
 import { adModeAtom } from "../../../modules/atoms/global";
 
 declare global {
@@ -52,7 +53,7 @@ const InnerAdSense: React.FC<AdsenseProps> = ({
 	}, []);
 
 	return (
-		<div className={className}>
+		<div className={clsx("text-center", className)}>
 			<ins
 				className="adsbygoogle"
 				style={{ display: "block" }}


### PR DESCRIPTION
- classNameに"text-center"を追加